### PR TITLE
refactor(geo): extract pure-domain Location, drop cache singleton

### DIFF
--- a/hyperion/domain/geo.py
+++ b/hyperion/domain/geo.py
@@ -1,0 +1,205 @@
+"""Pure-domain geographical primitives.
+
+Split out of :mod:`hyperion.infrastructure.geo.location` (F2 / DDD refactor
+Step 3). :class:`Location`, :class:`NamedLocation`, :class:`SpatialKMeans` and
+the distance/conversion helpers are pure data + math: they depend only on the
+stdlib, ``haversine`` (lite core) and lite-core :mod:`hyperion.log`.
+
+There is **no cache reference and no singleton** here -- the old
+``Location._cache`` class variable (which pulled :class:`hyperion.ports.cache.Cache`
+and, via ``Cache.from_config()``, ``boto3``) is gone. ``get_distance`` simply
+computes the haversine (or, when ``approximate``, the equirectangular)
+distance; callers that want memoisation wrap it themselves
+(e.g. :func:`functools.lru_cache`).
+
+``numpy`` is imported lazily inside :class:`SpatialKMeans`, so this module
+never *requires* numpy itself; only ``SpatialKMeans`` use does (it raises a
+clear ``ImportError`` without it). ``haversine`` does its own optional
+``import numpy`` at load *iff numpy is installed* (a vector fast-path -- not a
+declared haversine dependency) and falls back to a pure-``math`` scalar path
+when absent, which is the path :meth:`Location.get_distance` uses. numpy is
+therefore safely gated under the ``[data]`` extra; the dependency move itself
+lands in DDD refactor Step 10.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Generic, TypeVar, cast
+
+import haversine
+from haversine.haversine import get_avg_earth_radius
+
+from hyperion.log import get_logger
+
+if TYPE_CHECKING:
+    import numpy as np
+    import numpy.typing as npt
+
+LATITUDE_DEGREE_TO_METERS = 111_000
+EARTH_RADIUS_METERS = get_avg_earth_radius(haversine.Unit.METERS)
+
+logger = get_logger("hyperion-geo")
+
+AnyLocation = TypeVar("AnyLocation", bound="Location")
+
+
+def meters_to_degrees(meters: float, at_latitude: float) -> tuple[float, float]:
+    """Convert meters to degrees at a given latitude.
+
+    Args:
+        meters (float): The distance in meters.
+        at_latitude (float): The latitude at which the conversion should be done.
+
+    Returns:
+        tuple[float, float]: The distance in degrees for latitude and longitude.
+    """
+    return meters / LATITUDE_DEGREE_TO_METERS, meters / (
+        LATITUDE_DEGREE_TO_METERS * math.cos(math.radians(at_latitude))
+    )
+
+
+class SpatialKMeans(Generic[AnyLocation]):
+    """K-means clustering for geographical locations."""
+
+    def __init__(self, locations: Iterable[AnyLocation]) -> None:
+        """Initialize the K-means clustering with the given locations.
+
+        Args:
+            locations (Iterable[Location]): The locations to cluster.
+        """
+        import numpy as np
+
+        self.locations = list(locations)
+        self.locations_array = np.array(
+            [[location.latitude, location.longitude] for location in self.locations],
+        )
+
+    def _get_distances_from_centroids(self, centroids: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+        import numpy as np
+
+        return np.array(
+            [
+                [haversine.haversine((point[0], point[1]), (centroid[0], centroid[1])) for centroid in centroids]
+                for point in self.locations_array
+            ]
+        )
+
+    def fit(self, k: int, max_iters: int = 100) -> dict[Location, list[AnyLocation]]:
+        """Fit the K-means model with k clusters and return the clusters.
+
+        Args:
+            k (int): The desired number of clusters (must be less than the number of locations).
+            max_iters (int, optional): The maximum number of iterations. Defaults to 100.
+
+        Returns:
+            dict[Location, list[Location]]: The clusters with the centroids as keys.
+        """
+        import numpy as np
+
+        centroids = self.locations_array[np.random.choice(len(self.locations_array), k, replace=False), :2]
+
+        for _ in range(max_iters):
+            distances = self._get_distances_from_centroids(centroids)
+
+            cluster_assignments = np.argmin(distances, axis=1)
+
+            new_centroids_list = []
+            for cluster_idx in range(k):
+                cluster_points = self.locations_array[cluster_assignments == cluster_idx, :2]
+                if len(cluster_points) > 0:
+                    new_centroids_list.append(cluster_points.mean(axis=0))
+                else:
+                    new_centroids_list.append(centroids[cluster_idx])  # Keep old centroid for empty clusters
+            new_centroids = np.array(new_centroids_list)
+
+            if np.allclose(centroids, new_centroids):
+                break
+            centroids = new_centroids
+
+        clusters: dict[Location, list[AnyLocation]] = defaultdict(list)
+        centroid_locations = [Location(float(lat), float(lon)) for lat, lon in centroids]
+
+        for location_id, centroid_id in enumerate(cluster_assignments):
+            clusters[centroid_locations[centroid_id]].append(self.locations[location_id])
+        return dict(clusters)
+
+
+@dataclass(frozen=True, eq=True)
+class Location:
+    """A geographical location."""
+
+    latitude: float
+    longitude: float
+    title: str | None = None
+    address: str | None = None
+
+    def _get_distance_haversine(self, other: Location) -> float:
+        return cast(
+            float,
+            haversine.haversine(
+                (self.latitude, self.longitude), (other.latitude, other.longitude), haversine.Unit.METERS
+            ),
+        )
+
+    def _get_distance_euclidean(self, other: Location) -> float:
+        lat_diff = math.radians(self.latitude - other.latitude)
+        lon_diff = math.radians(self.longitude - other.longitude)
+        x = lon_diff * math.cos(math.radians((self.latitude + other.latitude) / 2))
+        y = lat_diff
+        return cast(float, EARTH_RADIUS_METERS) * math.sqrt(x**2 + y**2)
+
+    def get_distance(self, other: Location, approximate: bool = False) -> float:
+        """Get the distance to another location in meters.
+        If approximate is False (default), will use haversine. Otherwise uses Euclidean to approximate the distance.
+
+        Args:
+            other (Location): The other location.
+            approximate (bool, optional): Whether to approximate the distance. Defaults to False.
+
+        Returns:
+            float: The distance in meters.
+        """
+        if approximate:
+            return self._get_distance_euclidean(other)
+        return self._get_distance_haversine(other)
+
+    def get_nearest(
+        self, others: Iterable[AnyLocation], threshold: float | None = None, approximate: bool = False
+    ) -> AnyLocation:
+        """Get the closest location from the iterable of locations.
+
+        If threshold is given and all locations are further than the threshold in meters, an ValueError is raised.
+
+        Args:
+            others (Iterable[Location]): The other locations.
+            threshold (float, optional): The maximum distance in meters. Defaults to None.
+            approximate (bool, optional): Whether to approximate the distance. Defaults to False.
+
+        Returns:
+            Location: The nearest location.
+        """
+        nearest: tuple[AnyLocation, float] | None = None
+        for other in others:
+            distance = self.get_distance(other, approximate=approximate)
+            if nearest is None or nearest[1] > distance:
+                nearest = (other, distance)
+        if nearest is None:
+            raise ValueError(f"None of the given locations is close enough to {self!r}.")
+        logger.debug("Found nearest location.", this=self, other=nearest[0], distance=nearest[1])
+        return nearest[0]
+
+
+@dataclass(frozen=True, eq=True)
+class NamedLocation:
+    location: Location
+    route: str | None = None
+    neighborhood: str | None = None
+    sublocality: str | None = None
+    administrative_area: str | None = None
+    administrative_area_level_2: str | None = None
+    country: str | None = None
+    address: str | None = None

--- a/hyperion/infrastructure/geo/__init__.py
+++ b/hyperion/infrastructure/geo/__init__.py
@@ -1,5 +1,5 @@
+from hyperion.domain.geo import Location
 from hyperion.infrastructure.geo.gmaps import GoogleMaps
-from hyperion.infrastructure.geo.location import Location
 
 __all__ = [
     "GoogleMaps",

--- a/hyperion/infrastructure/geo/gmaps.py
+++ b/hyperion/infrastructure/geo/gmaps.py
@@ -9,8 +9,8 @@ import googlemaps
 
 from hyperion.config import geo_config
 from hyperion.domain.assets import PersistentStoreAsset
+from hyperion.domain.geo import Location, NamedLocation
 from hyperion.infrastructure.cache import PersistentCache
-from hyperion.infrastructure.geo.location import Location, NamedLocation
 from hyperion.log import get_logger
 
 logger = get_logger("gmaps")

--- a/hyperion/infrastructure/geo/location.py
+++ b/hyperion/infrastructure/geo/location.py
@@ -1,186 +1,61 @@
-"""Common location classes and functions."""
+"""Common location classes and functions.
 
-import math
-from collections import defaultdict
-from collections.abc import Iterable
-from dataclasses import dataclass
-from typing import ClassVar, Generic, TypeVar, cast
+.. deprecated::
+    The geographical primitives (:class:`Location`, :class:`NamedLocation`,
+    :class:`SpatialKMeans`, :func:`meters_to_degrees`, :data:`EARTH_RADIUS_METERS`,
+    :data:`LATITUDE_DEGREE_TO_METERS`) moved to :mod:`hyperion.domain.geo`
+    (F2 / DDD refactor Step 3) and the ``Location._cache`` singleton was
+    removed. Import them from :mod:`hyperion.domain.geo` instead. This module
+    keeps them importable (with a :class:`DeprecationWarning`, resolved lazily
+    so the import does not pull numpy) for the whole ``hyperion-sdk`` 1.x line.
+"""
 
-import haversine
-import numpy as np
-import numpy.typing as npt
-from haversine.haversine import get_avg_earth_radius
+from __future__ import annotations
 
-from hyperion.log import get_logger
-from hyperion.ports.cache import Cache
+import importlib
+from typing import TYPE_CHECKING
 
-LATITUDE_DEGREE_TO_METERS = 111_000
-EARTH_RADIUS_METERS = get_avg_earth_radius(haversine.Unit.METERS)
+from hyperion._compat import moved_attr
 
-logger = get_logger("hyperion-geo")
-
-AnyLocation = TypeVar("AnyLocation", bound="Location")
-
-
-def meters_to_degrees(meters: float, at_latitude: float) -> tuple[float, float]:
-    """Convert meters to degrees at a given latitude.
-
-    Args:
-        meters (float): The distance in meters.
-        at_latitude (float): The latitude at which the conversion should be done.
-
-    Returns:
-        tuple[float, float]: The distance in degrees for latitude and longitude.
-    """
-    return meters / LATITUDE_DEGREE_TO_METERS, meters / (
-        LATITUDE_DEGREE_TO_METERS * math.cos(math.radians(at_latitude))
+if TYPE_CHECKING:
+    from hyperion.domain.geo import (
+        EARTH_RADIUS_METERS,
+        LATITUDE_DEGREE_TO_METERS,
+        Location,
+        NamedLocation,
+        SpatialKMeans,
+        meters_to_degrees,
     )
 
+_MOVED: dict[str, str] = {
+    "LATITUDE_DEGREE_TO_METERS": "hyperion.domain.geo",
+    "EARTH_RADIUS_METERS": "hyperion.domain.geo",
+    "meters_to_degrees": "hyperion.domain.geo",
+    "SpatialKMeans": "hyperion.domain.geo",
+    "Location": "hyperion.domain.geo",
+    "NamedLocation": "hyperion.domain.geo",
+}
 
-class SpatialKMeans(Generic[AnyLocation]):
-    """K-means clustering for geographical locations."""
+__all__ = [
+    "EARTH_RADIUS_METERS",
+    "LATITUDE_DEGREE_TO_METERS",
+    "Location",
+    "NamedLocation",
+    "SpatialKMeans",
+    "meters_to_degrees",
+]
 
-    def __init__(self, locations: Iterable[AnyLocation]) -> None:
-        """Initialize the K-means clustering with the given locations.
 
-        Args:
-            locations (Iterable[Location]): The locations to cluster.
-        """
-        self.locations = list(locations)
-        self.locations_array = np.array(
-            [[location.latitude, location.longitude] for location in self.locations],
+def __getattr__(name: str) -> object:
+    if name in _MOVED:
+        new_module = _MOVED[name]
+        # Deferred import: a deprecated geo import must not pull numpy -- only
+        # `hyperion.domain.geo.SpatialKMeans` use does.
+        module = importlib.import_module(new_module)
+        return moved_attr(
+            name=name,
+            value=getattr(module, name),
+            old_module="hyperion.infrastructure.geo.location",
+            new_module=new_module,
         )
-
-    def _get_distances_from_centroids(self, centroids: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
-        return np.array(
-            [
-                [haversine.haversine((point[0], point[1]), (centroid[0], centroid[1])) for centroid in centroids]
-                for point in self.locations_array
-            ]
-        )
-
-    def fit(self, k: int, max_iters: int = 100) -> dict["Location", list[AnyLocation]]:
-        """Fit the K-means model with k clusters and return the clusters.
-
-        Args:
-            k (int): The desired number of clusters (must be less than the number of locations).
-            max_iters (int, optional): The maximum number of iterations. Defaults to 100.
-
-        Returns:
-            dict[Location, list[Location]]: The clusters with the centroids as keys.
-        """
-        centroids = self.locations_array[np.random.choice(len(self.locations_array), k, replace=False), :2]
-
-        for _ in range(max_iters):
-            distances = self._get_distances_from_centroids(centroids)
-
-            cluster_assignments = np.argmin(distances, axis=1)
-
-            new_centroids_list = []
-            for cluster_idx in range(k):
-                cluster_points = self.locations_array[cluster_assignments == cluster_idx, :2]
-                if len(cluster_points) > 0:
-                    new_centroids_list.append(cluster_points.mean(axis=0))
-                else:
-                    new_centroids_list.append(centroids[cluster_idx])  # Keep old centroid for empty clusters
-            new_centroids = np.array(new_centroids_list)
-
-            if np.allclose(centroids, new_centroids):
-                break
-            centroids = new_centroids
-
-        clusters: dict[Location, list[AnyLocation]] = defaultdict(list)
-        centroid_locations = [Location(float(lat), float(lon)) for lat, lon in centroids]
-
-        for location_id, centroid_id in enumerate(cluster_assignments):
-            clusters[centroid_locations[centroid_id]].append(self.locations[location_id])
-        return dict(clusters)
-
-
-@dataclass(frozen=True, eq=True)
-class Location:
-    """A geographical location."""
-
-    _cache: ClassVar[Cache | None] = None
-
-    latitude: float
-    longitude: float
-    title: str | None = None
-    address: str | None = None
-
-    @classmethod
-    def _get_cache(cls) -> Cache:
-        if cls._cache is None:
-            cls._cache = Cache.from_config()
-        return cls._cache
-
-    def _get_distance_haversine(self, other: "Location") -> float:
-        return cast(
-            float,
-            haversine.haversine(
-                (self.latitude, self.longitude), (other.latitude, other.longitude), haversine.Unit.METERS
-            ),
-        )
-
-    def _get_distance_euclidean(self, other: "Location") -> float:
-        lat_diff = math.radians(self.latitude - other.latitude)
-        lon_diff = math.radians(self.longitude - other.longitude)
-        x = lon_diff * math.cos(math.radians((self.latitude + other.latitude) / 2))
-        y = lat_diff
-        return cast(float, EARTH_RADIUS_METERS) * math.sqrt(x**2 + y**2)
-
-    def get_distance(self, other: "Location", approximate: bool = False) -> float:
-        """Get the distance to another location in meters.
-        If approximate is False (default), will use haversine. Otherwise uses Euclidean to approximate the distance.
-
-        Args:
-            other (Location): The other location.
-            approximate (bool, optional): Whether to approximate the distance. Defaults to False.
-
-        Returns:
-            float: The distance in meters.
-        """
-        cache_key = str((self.latitude, self.longitude, other.latitude, other.longitude, approximate))
-        cache = self._get_cache()
-        if cached := cache.get(cache_key):
-            return float(cached)
-        if approximate:
-            return self._get_distance_euclidean(other)
-        return self._get_distance_haversine(other)
-
-    def get_nearest(
-        self, others: Iterable[AnyLocation], threshold: float | None = None, approximate: bool = False
-    ) -> AnyLocation:
-        """Get the closest location from the iterable of locations.
-
-        If threshold is given and all locations are further than the threshold in meters, an ValueError is raised.
-
-        Args:
-            others (Iterable[Location]): The other locations.
-            threshold (float, optional): The maximum distance in meters. Defaults to None.
-            approximate (bool, optional): Whether to approximate the distance. Defaults to False.
-
-        Returns:
-            Location: The nearest location.
-        """
-        nearest: tuple[AnyLocation, float] | None = None
-        for other in others:
-            distance = self.get_distance(other, approximate=approximate)
-            if nearest is None or nearest[1] > distance:
-                nearest = (other, distance)
-        if nearest is None:
-            raise ValueError(f"None of the given locations is close enough to {self!r}.")
-        logger.debug("Found nearest location.", this=self, other=nearest[0], distance=nearest[1])
-        return nearest[0]
-
-
-@dataclass(frozen=True, eq=True)
-class NamedLocation:
-    location: Location
-    route: str | None = None
-    neighborhood: str | None = None
-    sublocality: str | None = None
-    administrative_area: str | None = None
-    administrative_area_level_2: str | None = None
-    country: str | None = None
-    address: str | None = None
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/infrastructure/geo/test_location.py
+++ b/tests/infrastructure/geo/test_location.py
@@ -1,17 +1,17 @@
-"""Tests for `hyperion.infrastructure.geo.location`.
+"""Tests for the deprecated `hyperion.infrastructure.geo.location` path.
 
-The DDD refactor (F2) will move `Location` to `hyperion/domain/geo.py` and
-remove the `Location._cache` class variable. These tests pin the distance math
-and dataclass shapes so the cache-less version can be proven equivalent.
+The DDD refactor (F2 / Step 3) moved `Location`, `NamedLocation`,
+`SpatialKMeans` and the distance helpers to `hyperion/domain/geo.py` and removed
+the `Location._cache` class variable. These tests deliberately keep importing
+from the old `hyperion.infrastructure.geo.location` path so the deprecation
+shim stays exercised, and pin the (now cache-less) distance math.
 """
 
 import datetime
-from collections.abc import Iterator
 
 import numpy as np
 import pytest
 
-from hyperion.infrastructure.cache import Cache, InMemoryCache
 from hyperion.infrastructure.geo.location import (
     EARTH_RADIUS_METERS,
     Location,
@@ -21,33 +21,6 @@ from hyperion.infrastructure.geo.location import (
 )
 
 
-@pytest.fixture
-def isolated_location_cache() -> Iterator[InMemoryCache]:
-    # Location._cache is a *class variable*. Save/restore it so tests don't
-    # contaminate each other, and so the test doesn't depend on env-driven
-    # Cache.from_config() (which reaches for DynamoDB by default).
-    previous: Cache | None = Location._cache
-    cache = InMemoryCache(prefix="test-location", default_ttl=3600)
-    Location._cache = cache
-    try:
-        yield cache
-    finally:
-        Location._cache = previous
-
-
-@pytest.fixture
-def _no_location_cache() -> Iterator[None]:
-    # Force cls._cache to a noop cache that returns None for everything,
-    # to exercise the "no cache hit" path without resolving Cache.from_config().
-    previous: Cache | None = Location._cache
-    Location._cache = InMemoryCache(prefix="empty", default_ttl=3600)
-    try:
-        yield
-    finally:
-        Location._cache = previous
-
-
-@pytest.mark.usefixtures("_no_location_cache")
 class TestHaversineDistance:
     def test_same_point_is_zero(self) -> None:
         location = Location(50.0, 14.0)
@@ -79,7 +52,6 @@ class TestHaversineDistance:
         assert a.get_distance(b) == pytest.approx(b.get_distance(a), rel=1e-9)
 
 
-@pytest.mark.usefixtures("_no_location_cache")
 class TestEuclideanDistance:
     def test_same_point_is_zero(self) -> None:
         location = Location(50.0, 14.0)
@@ -94,42 +66,21 @@ class TestEuclideanDistance:
         assert euclidean == pytest.approx(haversine_distance, rel=1e-2)
 
 
-class TestDistanceCacheParity:
-    def test_uncached_call_returns_math_result(self, isolated_location_cache: InMemoryCache) -> None:
-        # Cache empty → must return the haversine math directly.
+class TestDistanceMath:
+    def test_call_returns_haversine_math_result(self) -> None:
         a = Location(0.0, 0.0)
         b = Location(0.0, 1.0)
         result = a.get_distance(b)
         assert result == pytest.approx(111_195, rel=1e-3)
 
-    def test_cached_value_is_used(self, isolated_location_cache: InMemoryCache) -> None:
-        # Pre-populate the cache; the cached value is returned even though
-        # it's wildly wrong, proving the cache lookup runs.
-        a = Location(0.0, 0.0)
-        b = Location(0.0, 1.0)
-        cache_key = str((a.latitude, a.longitude, b.latitude, b.longitude, False))
-        isolated_location_cache.set(cache_key, "9999999")
-        assert a.get_distance(b) == 9999999.0
-
-    def test_uncached_path_is_unaffected_by_cache_removal(
-        self, isolated_location_cache: InMemoryCache
-    ) -> None:
-        # The current implementation does not write into the cache on a miss,
-        # so removing the cache layer (F2) must not change uncached-call output.
+    def test_get_distance_equals_haversine_helper(self) -> None:
+        # F2 removed the (write-never) cache layer; get_distance must return
+        # exactly the haversine math for the non-approximate path.
         a = Location(48.8566, 2.3522)
         b = Location(52.52, 13.405)
-        with_cache = a.get_distance(b)
-        # Re-call after clearing the cache reference path entirely.
-        Location._cache = None
-        try:
-            isolated_location_cache.clear()
-            second = a._get_distance_haversine(b)
-        finally:
-            Location._cache = isolated_location_cache
-        assert with_cache == pytest.approx(second, rel=1e-12)
+        assert a.get_distance(b) == pytest.approx(a._get_distance_haversine(b), rel=1e-12)
 
 
-@pytest.mark.usefixtures("_no_location_cache")
 class TestGetNearest:
     def test_picks_closest(self) -> None:
         origin = Location(0.0, 0.0)
@@ -143,7 +94,6 @@ class TestGetNearest:
             origin.get_nearest([])
 
 
-@pytest.mark.usefixtures("_no_location_cache")
 class TestNamedLocation:
     def test_frozen_and_equal(self) -> None:
         loc = Location(0.0, 0.0)
@@ -177,7 +127,6 @@ class TestMetersToDegrees:
         assert lon_deg == pytest.approx(2.0, rel=1e-9)
 
 
-@pytest.mark.usefixtures("_no_location_cache")
 class TestSpatialKMeans:
     def test_deterministic_with_seeded_rng(self) -> None:
         # Two tight clusters; with a seeded numpy RNG, the result is stable.

--- a/tests/test_import_graph.py
+++ b/tests/test_import_graph.py
@@ -30,11 +30,7 @@ HEAVY_MODULES = {
 
 def _loaded_modules(module_name: str) -> set[str]:
     """Spawn a fresh interpreter, import the module, return `sys.modules.keys()`."""
-    program = (
-        f"import {module_name}\n"
-        "import sys, json\n"
-        "print(json.dumps(list(sys.modules.keys())))\n"
-    )
+    program = f"import {module_name}\nimport sys, json\nprint(json.dumps(list(sys.modules.keys())))\n"
     result = subprocess.run(  # noqa: S603 - trusted args (sys.executable + literal program)
         [sys.executable, "-c", program],
         capture_output=True,
@@ -58,6 +54,7 @@ def _heavy_pulled_in(module_name: str) -> set[str]:
 
 # -- These modules must remain lite today and forever --
 
+
 @pytest.mark.parametrize(
     "module",
     [
@@ -78,6 +75,7 @@ def test_lite_core_module_pulls_no_heavy_deps(module: str) -> None:
 #    stack -- this guards the deferred-import / TYPE_CHECKING wiring. The cache
 #    and keyval ports legitimately use snappy for (de)compression, so snappy is
 #    deliberately not asserted against. --
+
 
 @pytest.mark.parametrize(
     "module",
@@ -107,6 +105,7 @@ def test_annotation_only_ports_stay_lite(module: str) -> None:
 #    and the entities.catalog / domain.assets identity layer no longer pulls
 #    the data stack. These must stay lite today and forever. --
 
+
 def test_typeutils_does_not_pull_data_stack() -> None:
     assert _heavy_pulled_in("hyperion.typeutils") == set()
 
@@ -119,9 +118,32 @@ def test_domain_assets_does_not_pull_data_stack() -> None:
     assert _heavy_pulled_in("hyperion.domain.assets") == set()
 
 
+# -- S3 (F2) landed: hyperion.domain.geo is pure data + haversine math. It must
+#    not pull boto3 / the data stack, and -- crucially for F2 -- must not pull
+#    the cache port (the Location._cache singleton that reached boto3 via
+#    Cache.from_config is gone). `numpy` is deliberately NOT asserted against:
+#    `haversine` (lite core) does an optional `import numpy` at module load
+#    *iff numpy is installed* (its vector fast-path); it is not a declared
+#    haversine dependency and the scalar path Location uses works without it, so
+#    SpatialKMeans imports numpy lazily and numpy is [data]-gated at the install
+#    level (Step 10 / the no-extras smoke test), not by this in-env guard. --
+
+
+def test_domain_geo_stays_lite() -> None:
+    forbidden = {"boto3", "botocore", "aioboto3", "polars", "pandera", "fastavro", "googlemaps"} & _heavy_pulled_in(
+        "hyperion.domain.geo"
+    )
+    assert forbidden == set(), f"hyperion.domain.geo unexpectedly imports {sorted(forbidden)}"
+
+
+def test_domain_geo_does_not_pull_cache_port() -> None:
+    assert "hyperion.ports.cache" not in _loaded_modules("hyperion.domain.geo")
+
+
 # -- This module currently violates the promise; the refactor fixes it --
 # `strict=True` means the marker fails CI as soon as the test starts passing —
 # forcing the marker to be removed when the corresponding refactor step lands.
+
 
 @pytest.mark.xfail(
     strict=True,


### PR DESCRIPTION
## Summary

DDD refactor **S3** (`#128`, epic #137). Fixes **F2** (the `geo` subpackage transitively pulled `[aws]`) and the `Location._cache` slice of **F9** (class-level mutable singleton). Pure structural refactor — no new APIs, no behaviour change.

- **New `hyperion/domain/geo.py`** — `Location`, `NamedLocation`, `SpatialKMeans`, `meters_to_degrees`, `EARTH_RADIUS_METERS`, `LATITUDE_DEGREE_TO_METERS`. Pure data + haversine math, no cache, no singletons.
- **Dropped `Location._cache` / `Location._get_cache()`**. This is **provably zero behaviour change**: the old `get_distance()` only ever called `cache.get()` and *never* `cache.set()` (`location.py:143-149`), so the cache was always empty in normal operation and the math path always ran. The plan's conditional `application/geo_distance_service.py` fallback (plan:238) therefore does not trigger.
- **`hyperion/infrastructure/geo/location.py` → deferred deprecation shim** reusing the established S1/S2 `_compat.moved_attr` + PEP 562 `__getattr__` recipe. Every old symbol still resolves to the *same object* and emits a `DeprecationWarning` pointing at `hyperion.domain.geo`. Shim removed in 2.0.
- **First-party imports migrated** (`infrastructure/geo/__init__.py`, `gmaps.py`) to `hyperion.domain.geo`; tests keep the old path as the deprecation regression signal (house rule).
- **Import-graph guards** added: `hyperion.domain.geo` pulls no boto3 / data stack and never `hyperion.ports.cache`.

## numpy gating decision (issue asked to *decide & document*)

**numpy CAN be `[data]`-gated.** `SpatialKMeans` imports numpy lazily, so `hyperion.domain.geo` never *requires* numpy itself. Investigation showed `haversine` (lite-core, required for the core distance math) does its **own optional `import numpy`** at module load *only if numpy is installed* — it is **not a declared `haversine` dependency**, and `haversine` falls back to a pure-`math` **scalar** path when numpy is absent. That scalar path is exactly what `Location.get_distance()` uses, so a lite install without numpy still computes distances correctly; only `SpatialKMeans` needs numpy and raises a clear `ImportError` without it.

Consequence for the import-graph guard: numpy is *deliberately not asserted against* for `hyperion.domain.geo` (it arrives via `haversine`'s opportunistic import whenever numpy is installed in the env — by design, mirroring how `snappy` is handled for the cache/keyval ports). numpy's absence in a lite install is enforced at the **install level by S10's no-extras smoke test**, not by this in-process guard. The actual `numpy → [data]` `pyproject.toml` move is **deferred to S10 (#136)** — the single `build!:` step — keeping S3 a **non-bumping `refactor:`** commit per the epic release strategy.

## Verification

- `pytest -q`: **396 passed, 1 xfailed** (the expected F8/S9 marker), 30 warnings (intended deprecation signal — `filterwarnings` does not escalate it).
- `mypy --strict hyperion`: clean (40 files).
- `ruff check` / `ruff format` / `pre-commit` (mypy, ruff, secrets): pass on changed files.
- `import hyperion.infrastructure.geo.location` does **not** warn; `from ... import Location` **does** warn and `Location is hyperion.domain.geo.Location`.
- `import hyperion.domain.geo` pulls no `boto3`/`polars`/`pandera`/`fastavro`/`googlemaps` and no `hyperion.ports.cache`.

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)