### PR TITLE
refactor(catalog): depend on StoragePort, extract avro serializer

### DIFF
--- a/hyperion/adapters/serialization/__init__.py
+++ b/hyperion/adapters/serialization/__init__.py
@@ -1,0 +1,6 @@
+"""Serialization adapters.
+
+Empty on purpose: no eager re-exports so touching the ``hyperion.adapters``
+namespace stays free of the ``[catalog]`` (fastavro) dependency. Import the
+concrete serializer explicitly from :mod:`hyperion.adapters.serialization.avro`.
+"""

--- a/hyperion/adapters/serialization/avro.py
+++ b/hyperion/adapters/serialization/avro.py
@@ -1,0 +1,90 @@
+"""Avro serialization adapter (requires the ``[catalog]`` extra -- fastavro).
+
+This is the *only* module that imports :mod:`fastavro`. It was extracted out of
+:class:`hyperion.catalog.catalog.Catalog` (DDD refactor F1 / Step 5) so that the
+catalog depends on an injected serializer instead of reaching for fastavro at
+module scope. ``Catalog`` default-constructs an :class:`AvroSerializer` when no
+serializer is supplied; importing this module is what gates the fastavro
+requirement, so the error below points at the extra to install.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from typing import IO, Any, Protocol, runtime_checkable
+
+try:
+    import fastavro
+    import fastavro.write
+except ImportError as error:  # pragma: no cover - exercised only without [catalog]
+    raise ImportError(
+        "Avro serialization requires the optional 'catalog' extra. "
+        "Install it with: pip install 'hyperion-sdk[catalog]'."
+    ) from error
+
+
+@runtime_checkable
+class AvroStreamWriter(Protocol):
+    """Incremental avro writer (one record at a time, then flushed).
+
+    Structural type for the object :meth:`AvroSerializer.streaming_writer`
+    returns, so callers (e.g. ``AssetRepartitioner``) need no fastavro import.
+    """
+
+    def write(self, record: dict[str, Any]) -> None:
+        """Append a single record to the open avro stream."""
+        ...
+
+    def dump(self) -> None:
+        """Flush all buffered records and the avro footer to the file."""
+        ...
+
+
+class AvroSerializer:
+    """Encapsulates the catalog's fastavro encode/decode contract.
+
+    The encode parameters (``deflate`` codec, compression level 7, validation,
+    lenient strictness) are pinned here so byte-level output is identical to the
+    pre-refactor inline implementation.
+    """
+
+    def write(
+        self,
+        fp: IO[bytes],
+        schema: dict[str, Any],
+        records: Iterable[dict[str, Any]],
+        metadata: dict[str, str],
+    ) -> None:
+        """Write ``records`` to ``fp`` as a single avro container file."""
+        fastavro.writer(
+            fp,
+            records=records,
+            schema=schema,
+            codec="deflate",
+            validator=True,
+            codec_compression_level=7,
+            strict=False,
+            strict_allow_default=True,
+            metadata=metadata,
+        )
+
+    def read(self, fp: IO[bytes]) -> Iterator[Any]:
+        """Yield raw records decoded from the avro container in ``fp``.
+
+        Type/shape validation of each row stays with the caller.
+        """
+        yield from fastavro.reader(fp)
+
+    def streaming_writer(self, fp: IO[bytes], schema: dict[str, Any], metadata: dict[str, str]) -> AvroStreamWriter:
+        """Open an incremental avro writer over ``fp`` (for repartitioning).
+
+        Mirrors the pre-refactor ``fastavro.write.Writer`` configuration (no
+        explicit compression level / strictness flags).
+        """
+        return fastavro.write.Writer(
+            fp,
+            schema=schema,
+            codec="deflate",
+            validator=True,
+            metadata=metadata,
+        )

--- a/hyperion/catalog/catalog.py
+++ b/hyperion/catalog/catalog.py
@@ -3,18 +3,15 @@
 import asyncio
 import datetime
 import re
+import shutil
 import tempfile
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Mapping
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any, BinaryIO, ClassVar, Generic, TypeAlias, TypedDict, TypeVar, cast
+from typing import IO, TYPE_CHECKING, Any, BinaryIO, ClassVar, Generic, TypeAlias, TypeVar, cast
 from uuid import uuid4
 
-import botocore.exceptions
-import fastavro
-import fastavro.validation
-import fastavro.write
-
+from hyperion.adapters.serialization.avro import AvroSerializer, AvroStreamWriter
 from hyperion.asyncutils import AsyncTaskQueue, aiter_any
 from hyperion.config import storage_config
 from hyperion.dateutils import (
@@ -28,16 +25,16 @@ from hyperion.dateutils import (
 )
 from hyperion.domain.assets import (
     AssetProtocol,
+    AssetType,
     DataLakeAsset,
     FeatureAsset,
     PersistentStoreAsset,
-    get_prefixed_path,
 )
-from hyperion.infrastructure.aws import S3Client
 from hyperion.infrastructure.message_queue import ArrivalEvent, DataLakeArrivalMessage
 from hyperion.log import get_logger
 from hyperion.ports.queue import Queue
 from hyperion.ports.schema_registry import SchemaStore
+from hyperion.ports.storage import ObjectNotFoundError, StoragePort
 
 if TYPE_CHECKING:
     from hyperion.ports.cache import Cache
@@ -48,13 +45,6 @@ logger = get_logger("catalog")
 
 RepartitionableAssetType: TypeAlias = FeatureAsset | DataLakeAsset
 RepartitionableAsset = TypeVar("RepartitionableAsset", bound=RepartitionableAssetType)
-
-
-class StoreBucketConfig(TypedDict):
-    """Configuration for storing assets in a bucket."""
-
-    bucket: str
-    prefix: str
 
 
 class CatalogError(Exception):
@@ -80,7 +70,7 @@ class PersistentStore:
 
     # TODO: Unfinished business
     # https://github.com/Zephyr-Trade/FVE-map/issues/9
-    _instances: ClassVar[dict[tuple[PersistentStoreAsset, str, str], "PersistentStore"]] = {}
+    _instances: ClassVar[dict[tuple[Any, ...], "PersistentStore"]] = {}
 
     def __new__(cls, *args: Any, **kwargs: Any) -> "PersistentStore":
         init_arguments = _unpack_args(*args, **kwargs)
@@ -88,19 +78,15 @@ class PersistentStore:
             cls._instances[init_arguments] = super().__new__(cls)
         return cls._instances[init_arguments]
 
-    def __init__(
-        self, asset: PersistentStoreAsset, persistent_store_bucket: str, persistent_store_prefix: str = ""
-    ) -> None:
+    def __init__(self, asset: PersistentStoreAsset, storage: StoragePort) -> None:
         """Initialize the persistent store.
 
         Args:
             asset (PersistentStoreAsset): The asset to store.
-            persistent_store_bucket (str): The bucket to store the asset in.
-            persistent_store_prefix (str): The prefix for the asset in the bucket.
+            storage (StoragePort): The storage backend the asset lives in.
         """
         self.asset = asset
-        self.persistent_store_bucket = persistent_store_bucket
-        self.persistent_store_prefix = persistent_store_prefix
+        self.storage = storage
         self._local_path: Path | None = None
         self._etag: str | None = None
 
@@ -119,16 +105,11 @@ class PersistentStore:
         self._local_path = None
 
     def retrieve(self) -> None:
-        """Retrieve the persistent store from the S3 bucket."""
-        s3_client = S3Client()
+        """Retrieve the persistent store from its storage backend."""
         try:
-            remote_etag = s3_client.get_object_attributes(
-                self.persistent_store_bucket, self.asset.get_path(self.persistent_store_prefix)
-            ).etag
-        except botocore.exceptions.ClientError as error:
-            if error.response["Error"]["Code"] == "NoSuchKey":
-                raise AssetNotFoundError(self.asset) from error
-            raise
+            remote_etag = self.storage.get_attributes(self.asset.get_path()).etag
+        except ObjectNotFoundError as error:
+            raise AssetNotFoundError(self.asset) from error
         if self._local_path is not None:
             if remote_etag == self._etag:
                 logger.info(
@@ -148,7 +129,8 @@ class PersistentStore:
 
         local_path = Path(tempfile.gettempdir()) / f"{uuid4().hex}.asset"
         logger.info("Retrieving persistent store.", asset=self.asset, path=local_path.as_posix())
-        s3_client.download(self.persistent_store_bucket, self.asset.get_path(self.persistent_store_prefix), local_path)
+        with self.storage.open(self.asset.get_path()) as source, local_path.open("wb") as destination:
+            shutil.copyfileobj(source, destination)
         self._local_path = local_path
         self._etag = remote_etag
 
@@ -173,25 +155,9 @@ class WritablePersistentStore(PersistentStore):
         with tempfile.TemporaryFile("+wb") as file:
             logger.info("Pouring persistent store asset into temporary file.", asset=self.asset, path=file.name)
             schema = SchemaStore.from_config().get_asset_schema(self.asset)
-            _write_avro(file, schema, data, self.asset.to_metadata())
-            s3_client = S3Client()
-            s3_client.upload(file, self.persistent_store_bucket, self.asset.get_path(self.persistent_store_prefix))
-
-
-def _write_avro(
-    fp: BinaryIO | IO[bytes], schema: dict[str, Any], data: Iterable[dict[str, Any]], metadata: dict[str, str]
-) -> None:
-    fastavro.writer(
-        fp,
-        records=data,
-        schema=schema,
-        codec="deflate",
-        validator=True,
-        codec_compression_level=7,
-        strict=False,
-        strict_allow_default=True,
-        metadata=metadata,
-    )
+            AvroSerializer().write(file, schema, data, self.asset.to_metadata())
+            file.seek(0)
+            self.storage.put(self.asset.get_path(), file)
 
 
 class Catalog:
@@ -200,43 +166,38 @@ class Catalog:
     The catalog is responsible for storing and retrieving assets.
     """
 
+    _ASSET_TYPES: ClassVar[tuple[AssetType, ...]] = ("data_lake", "feature", "persistent_store")
+
     def __init__(
         self,
         *,
-        data_lake_bucket: str,
-        feature_store_bucket: str,
-        persistent_store_bucket: str,
-        data_lake_prefix: str = "",
-        feature_store_prefix: str = "",
-        persistent_store_prefix: str = "",
+        storage: StoragePort | Mapping[AssetType, StoragePort],
         queue: Queue | None = None,
         cache: "Cache | None" = None,
         schema_store: "SchemaStore | None" = None,
+        serializer: AvroSerializer | None = None,
     ) -> None:
         """Initialize the catalog.
 
         Args:
-            data_lake_bucket (str): The bucket for data lake assets.
-            feature_store_bucket (str): The bucket for feature store assets.
-            persistent_store_bucket (str): The bucket for persistent store assets.
-            data_lake_prefix (str): The prefix for data lake assets.
-            feature_store_prefix (str): The prefix for feature store assets.
-            persistent_store_prefix (str): The prefix for persistent store assets.
+            storage (StoragePort | Mapping[AssetType, StoragePort]): The storage
+                backend. A single port serves every asset type; pass a mapping
+                keyed by asset type ("data_lake"/"feature"/"persistent_store")
+                to route each type to a different backend (this is how
+                :meth:`from_config` preserves today's per-bucket S3 layout).
             queue (Queue, optional): The queue to use for notifications. Defaults to None.
             cache (Cache, optional): The cache to use for storing assets for quicker re-retrieval. Defaults to None.
+            schema_store (SchemaStore, optional): The schema store. Defaults to ``SchemaStore.from_config()``.
+            serializer (AvroSerializer, optional): The avro serializer. Defaults to a fresh ``AvroSerializer``.
         """
-        self.data_lake_bucket = data_lake_bucket
-        self.feature_store_bucket = feature_store_bucket
-        self.persistent_store_bucket = persistent_store_bucket
-        self.data_lake_prefix = data_lake_prefix
-        self.feature_store_prefix = feature_store_prefix
-        self.persistent_store_prefix = persistent_store_prefix
-        self._config_map: dict[type[AssetProtocol], StoreBucketConfig] = {
-            DataLakeAsset: {"bucket": self.data_lake_bucket, "prefix": self.data_lake_prefix},
-            PersistentStoreAsset: {"bucket": self.persistent_store_bucket, "prefix": self.persistent_store_prefix},
-            FeatureAsset: {"bucket": self.feature_store_bucket, "prefix": self.feature_store_prefix},
-        }
-        self._s3_client: S3Client | None = None
+        if isinstance(storage, Mapping):
+            missing = [asset_type for asset_type in self._ASSET_TYPES if asset_type not in storage]
+            if missing:
+                raise ValueError(f"storage mapping is missing adapters for asset types: {missing}.")
+            self._storage: dict[AssetType, StoragePort] = dict(storage)
+        else:
+            self._storage = {asset_type: storage for asset_type in self._ASSET_TYPES}
+        self._serializer = serializer or AvroSerializer()
         self.queue = queue or Queue.from_config()
         self.cache = cache
         if self.cache is not None and not self.cache.hash_keys:
@@ -247,23 +208,36 @@ class Catalog:
 
         self.schema_store = schema_store or SchemaStore.from_config()
 
-    @property
-    def s3_client(self) -> S3Client:
-        """Get the S3 client."""
-        if self._s3_client is None:
-            self._s3_client = S3Client()
-        return self._s3_client
+    def _resolve_storage(self, asset: AssetProtocol | type[AssetProtocol]) -> StoragePort:
+        try:
+            return self._storage[asset.asset_type]
+        except KeyError:
+            logger.error("No storage configured for asset type.", asset=asset, asset_type=asset.asset_type)
+            raise
 
     @staticmethod
     def from_config() -> "Catalog":
-        """Create a catalog from the configuration."""
+        """Create a catalog from the configuration.
+
+        Builds one :class:`~hyperion.adapters.storage.s3.S3Storage` per asset
+        type so the on-S3 key layout (bucket + prefix per store) is identical to
+        the pre-refactor catalog. (Fixes a long-standing bug where the feature
+        store used the *data lake* prefix.)
+        """
+        from hyperion.adapters.storage.s3 import S3Storage
+
+        def _prefix(value: str) -> str:
+            value = value.strip("/")
+            return f"{value}/" if value else ""
+
         return Catalog(
-            data_lake_bucket=storage_config.data_lake_bucket,
-            feature_store_bucket=storage_config.feature_store_bucket,
-            persistent_store_bucket=storage_config.persistent_store_bucket,
-            data_lake_prefix=storage_config.data_lake_prefix,
-            feature_store_prefix=storage_config.data_lake_prefix,
-            persistent_store_prefix=storage_config.persistent_store_prefix,
+            storage={
+                "data_lake": S3Storage(storage_config.data_lake_bucket, _prefix(storage_config.data_lake_prefix)),
+                "feature": S3Storage(storage_config.feature_store_bucket, _prefix(storage_config.feature_store_prefix)),
+                "persistent_store": S3Storage(
+                    storage_config.persistent_store_bucket, _prefix(storage_config.persistent_store_prefix)
+                ),
+            }
         )
 
     @contextmanager
@@ -278,7 +252,7 @@ class Catalog:
             )
             path = Path(file.name)
             logger.info("Pouring asset into a temporary file.", asset=asset, file=path.as_posix())
-            _write_avro(file, schema, data, asset.to_metadata())
+            self._serializer.write(file, schema, data, asset.to_metadata())
             logger.info("Avro file was created successfully.", path=path.as_posix(), size=file.tell())
             file.seek(0)
             yield file
@@ -293,13 +267,10 @@ class Catalog:
             data (Iterable[dict[str, Any]]): The data to store.
             notify (bool, optional): Whether to send a notification. Defaults to True.
         """
-        store_config = self.get_store_config(asset)
-        logger.info("Preparing asset storage.", asset=asset, **store_config)
+        logger.info("Preparing asset storage.", asset=asset)
         with ExitStack() as stack:
             file = stack.enter_context(await asyncio.to_thread(self._prepare_asset_storage, asset, data, schema_path))
-            await self.s3_client.upload_async(
-                file, bucket=store_config["bucket"], name=asset.get_path(store_config["prefix"])
-            )
+            await self._resolve_storage(asset).put_async(asset.get_path(), file)
         if notify:
             self._notify_asset_arrival(asset, schema_path=schema_path)
 
@@ -345,20 +316,11 @@ class Catalog:
             data (Iterable[dict[str, Any]]): The data to store.
             notify (bool, optional): Whether to send a notification. Defaults to True.
         """
-        store_config = self.get_store_config(asset)
-        logger.info("Preparing asset storage.", asset=asset, **store_config)
+        logger.info("Preparing asset storage.", asset=asset)
         with self._prepare_asset_storage(asset, data, schema_path) as file:
-            self.s3_client.upload(file, bucket=store_config["bucket"], name=asset.get_path(store_config["prefix"]))
+            self._resolve_storage(asset).put(asset.get_path(), file)
         if notify:
             self._notify_asset_arrival(asset, schema_path=schema_path)
-
-    def get_store_config(self, asset: AssetProtocol | type[AssetProtocol]) -> StoreBucketConfig:
-        try:
-            config_key = asset if isinstance(asset, type) else asset.__class__
-            return self._config_map[config_key]
-        except KeyError:
-            logger.error("Attempting to get store config for an unsupported asset type.", asset=asset)
-            raise
 
     def get_asset_file_size(self, asset: AssetProtocol) -> int:
         """Find asset avro file and get its file size in bytes.
@@ -369,26 +331,19 @@ class Catalog:
         Returns:
             int: The file size in bytes.
         """
-        store_config = self.get_store_config(asset)
-
-        object_path = asset.get_path(store_config["prefix"])
-        logger.info("Getting attributes for an asset.", asset=asset, **store_config)
+        logger.info("Getting attributes for an asset.", asset=asset)
         try:
-            return self.s3_client.get_object_attributes(store_config["bucket"], object_path).object_size
-        except botocore.exceptions.ClientError as error:
-            if error.response["Error"]["Code"] == "NoSuchKey":
-                raise AssetNotFoundError(asset) from error
-            raise
+            return self._resolve_storage(asset).get_attributes(asset.get_path()).size
+        except ObjectNotFoundError as error:
+            raise AssetNotFoundError(asset) from error
 
     def _get_cache_key(self, asset: AssetProtocol) -> str:
-        store_config = self.get_store_config(asset)
-        path = asset.get_path(store_config["prefix"])
-        return f"{store_config['bucket']}:{path}"
+        return f"{asset.asset_type}:{asset.get_path()}"
 
     def _iter_data_from_downloaded_asset(
         self, file: BinaryIO | IO[bytes], asset: AssetProtocol
     ) -> Iterator[dict[str, Any]]:
-        for row_number, row in enumerate(fastavro.reader(file), start=1):
+        for row_number, row in enumerate(self._serializer.read(file), start=1):
             if isinstance(row, dict):
                 yield row
             else:
@@ -402,14 +357,12 @@ class Catalog:
                 raise TypeError(f"Unexpected data received when reading downloaded asset data, row {row_number}")
 
     def _download_asset_into_file(self, asset: AssetProtocol, file: IO[bytes]) -> None:
-        store_config = self.get_store_config(asset)
         logger.info("Downloading asset into a file.", asset=asset, path=getattr(file, "name", None) or "unnamed")
         try:
-            self.s3_client.download(store_config["bucket"], asset.get_path(store_config["prefix"]), file)
-        except botocore.exceptions.ClientError as error:
-            if error.response.get("Error", {}).get("Code") == "404":
-                raise AssetNotFoundError(asset) from error
-            raise
+            with self._resolve_storage(asset).open(asset.get_path()) as source:
+                shutil.copyfileobj(source, file)
+        except ObjectNotFoundError as error:
+            raise AssetNotFoundError(asset) from error
 
     @contextmanager
     def _get_asset_file_handle(self, asset: AssetProtocol, *, no_cache: bool = False) -> Iterator[IO[bytes]]:
@@ -453,18 +406,18 @@ class Catalog:
         Yields:
             DataLakeAsset: The data lake asset.
         """
-        store_config = self.get_store_config(DataLakeAsset)
-        keys_prefix = get_prefixed_path(f"{asset_name}/date={date_part if date_part else ''}", store_config["prefix"])
+        storage = self._resolve_storage(DataLakeAsset)
+        # The adapter owns its own storage-side prefix and yields keys relative
+        # to it, so iterate in the bare asset namespace.
+        keys_prefix = f"{asset_name}/date={date_part if date_part else ''}"
         version_patt = re.compile(r"v(?P<version>\d+)\.avro")
-        for key in self.s3_client.iter_objects(store_config["bucket"], keys_prefix):
-            key_without_prefix = key[len(self.data_lake_prefix) :] if self.data_lake_prefix else key
+        for key in storage.iter_keys(keys_prefix):
             try:
-                key_asset_name, partition, filename = key_without_prefix.split("/")
+                key_asset_name, partition, filename = key.split("/")
             except ValueError:
                 logger.warning(
                     "The key path does not have 'Asset/Partition/Version' format and will be skipped.",
                     key=key,
-                    key_without_prefix=key_without_prefix,
                 )
                 continue
             if key_asset_name != asset_name:
@@ -596,7 +549,7 @@ class AssetRepartitioner(Generic[RepartitionableAsset]):
         self.date_attribute = date_attribute
         self._partition_name = "date" if isinstance(self.asset, DataLakeAsset) else "timestamp"
 
-        self._state: dict[datetime.datetime, tuple[IO[bytes], RepartitionableAsset, fastavro.write.Writer]] = {}
+        self._state: dict[datetime.datetime, tuple[IO[bytes], RepartitionableAsset, AvroStreamWriter]] = {}
 
     def __enter__(self) -> None:
         self._state = {}
@@ -624,19 +577,15 @@ class AssetRepartitioner(Generic[RepartitionableAsset]):
 
     def _get_handler(
         self, partition_date: datetime.datetime
-    ) -> tuple[IO[bytes], RepartitionableAsset, fastavro.write.Writer]:
+    ) -> tuple[IO[bytes], RepartitionableAsset, AvroStreamWriter]:
         if partition_date in self._state:
             return self._state[partition_date]
         logger.info("Creating a new handler for partition date.", partition_date=partition_date.isoformat())
         file = tempfile.NamedTemporaryFile("+wb")  # noqa: SIM115
         logger.info(f"Partition will be temporarily stored in {file.name!r}.", path=file.name)
         asset = self._create_partition_asset(partition_date)
-        writer = fastavro.write.Writer(
-            file,
-            schema=self.catalog.schema_store.get_asset_schema(asset),
-            codec="deflate",
-            validator=True,
-            metadata=asset.to_metadata(),
+        writer = self.catalog._serializer.streaming_writer(
+            file, self.catalog.schema_store.get_asset_schema(asset), asset.to_metadata()
         )
         handler = (file, asset, writer)
         self._state[partition_date] = handler
@@ -664,7 +613,6 @@ class AssetRepartitioner(Generic[RepartitionableAsset]):
                 partition_date = truncate_datetime(timestamp, self.granularity)
                 _, __, writer = self._get_handler(partition_date)
                 writer.write(record)
-            store_config = self.catalog.get_store_config(self.asset)
             logger.info("Finished creating partitioned avro files.")
 
             async with AsyncTaskQueue[None](maxsize=5) as queue:
@@ -672,8 +620,4 @@ class AssetRepartitioner(Generic[RepartitionableAsset]):
                     logger.info("Dumping and uploading asset from temporary file.", asset=asset, path=file.name)
                     writer.dump()
                     file.seek(0)
-                    await queue.add_task(
-                        self.catalog.s3_client.upload_async(
-                            file, bucket=store_config["bucket"], name=asset.get_path(store_config["prefix"])
-                        )
-                    )
+                    await queue.add_task(self.catalog._resolve_storage(asset).put_async(asset.get_path(), file))

--- a/tests/adapters/serialization/test_avro.py
+++ b/tests/adapters/serialization/test_avro.py
@@ -1,0 +1,62 @@
+"""Unit tests for the extracted avro serialization adapter (DDD Step 5)."""
+
+import io
+
+import fastavro
+import pytest
+
+from hyperion.adapters.serialization.avro import AvroSerializer, AvroStreamWriter
+
+SCHEMA = {
+    "type": "record",
+    "name": "Sample",
+    "fields": [
+        {"name": "id", "type": "string"},
+        {"name": "count", "type": "long"},
+    ],
+}
+RECORDS = [{"id": "a", "count": 1}, {"id": "b", "count": 2}]
+METADATA = {"name": "sample", "schema_version": "1"}
+
+
+@pytest.fixture
+def serializer() -> AvroSerializer:
+    return AvroSerializer()
+
+
+def test_write_then_read_round_trips(serializer: AvroSerializer) -> None:
+    buffer = io.BytesIO()
+    serializer.write(buffer, SCHEMA, RECORDS, METADATA)
+    buffer.seek(0)
+    assert list(serializer.read(buffer)) == RECORDS
+
+
+def test_write_embeds_metadata(serializer: AvroSerializer) -> None:
+    buffer = io.BytesIO()
+    serializer.write(buffer, SCHEMA, RECORDS, METADATA)
+    buffer.seek(0)
+    reader = fastavro.reader(buffer)
+    list(reader)
+    decoded = {
+        k.decode() if isinstance(k, bytes) else k: v.decode() if isinstance(v, bytes) else v
+        for k, v in dict(reader.metadata).items()
+    }
+    assert decoded.get("name") == "sample"
+    assert decoded.get("schema_version") == "1"
+
+
+def test_write_validates_records(serializer: AvroSerializer) -> None:
+    buffer = io.BytesIO()
+    with pytest.raises(fastavro.validation.ValidationError):
+        serializer.write(buffer, SCHEMA, [{"id": None, "count": 1}], METADATA)
+
+
+def test_streaming_writer_round_trips(serializer: AvroSerializer) -> None:
+    buffer = io.BytesIO()
+    writer = serializer.streaming_writer(buffer, SCHEMA, METADATA)
+    assert isinstance(writer, AvroStreamWriter)
+    for record in RECORDS:
+        writer.write(record)
+    writer.dump()
+    buffer.seek(0)
+    assert list(serializer.read(buffer)) == RECORDS

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -2,6 +2,7 @@ import datetime
 import io
 import json
 import re
+import types
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -13,10 +14,10 @@ import pytest
 from hyperion.adapters.storage.filesystem import FilesystemStorage
 from hyperion.adapters.storage.memory import MemoryStorage
 from hyperion.adapters.storage.s3 import S3Storage
-from hyperion.catalog.catalog import AssetNotFoundError, Catalog
+from hyperion.catalog.catalog import AssetNotFoundError, Catalog, PersistentStore, WritablePersistentStore
 from hyperion.catalog.schema import LocalSchemaStore
 from hyperion.dateutils import TimeResolution, assure_timezone, quantize_datetime, utcnow
-from hyperion.domain.assets import AssetProtocol, DataLakeAsset, FeatureAsset
+from hyperion.domain.assets import AssetProtocol, DataLakeAsset, FeatureAsset, PersistentStoreAsset
 from hyperion.infrastructure.cache import LocalFileCache
 from hyperion.infrastructure.message_queue import (
     ArrivalEvent,
@@ -336,8 +337,6 @@ def test_from_config_uses_correct_per_store_prefixes(monkeypatch: pytest.MonkeyP
     Pins the Step 5 bug-fix: the pre-refactor `from_config()` fed the data-lake
     prefix into the feature store.
     """
-    import types
-
     fake_config = types.SimpleNamespace(
         data_lake_bucket="dl-bucket",
         feature_store_bucket="fs-bucket",
@@ -562,3 +561,116 @@ class TestFeatureStorePartitionQuantization:
             catalog.iter_feature_store_partitions("superfeature", TimeResolution(1, "d"), date_from, date_to)
         )
         assert {p.partition_date for p in partitions} == set(SUPERFEATURE_PARTITION_DATES)
+
+
+# -----------------------------------------------------------------------------
+# Storage-port rewiring of the previously S3Client-only / untested paths
+# (persistent store, async store, repartitioner). Now trivially testable
+# against MemoryStorage.
+# -----------------------------------------------------------------------------
+
+_PSTORE_SCHEMA = {"type": "record", "name": "PStore", "fields": [{"name": "id", "type": "string"}]}
+_TS_SCHEMA = {
+    "type": "record",
+    "name": "Repart",
+    "fields": [
+        {"name": "id", "type": "string"},
+        {"name": "timestamp", "type": {"type": "long", "logicalType": "timestamp-micros"}},
+    ],
+}
+
+
+class TestPersistentStore:
+    @pytest.fixture(autouse=True)
+    def _isolate_singletons(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # PersistentStore caches instances on a shared class-level dict.
+        PersistentStore._instances.clear()
+        # WritablePersistentStore.store() builds its schema store from env.
+        monkeypatch.setattr(
+            "hyperion.catalog.catalog.SchemaStore",
+            types.SimpleNamespace(
+                from_config=lambda: types.SimpleNamespace(get_asset_schema=lambda asset: _PSTORE_SCHEMA)
+            ),
+        )
+
+    def test_write_then_retrieve_round_trip(self) -> None:
+        storage = MemoryStorage()
+        asset = PersistentStoreAsset("pstore")
+        WritablePersistentStore(asset, storage).store([{"id": "a"}, {"id": "b"}])
+
+        # Decode straight from storage to confirm the bytes round-trip.
+        raw = storage.get(asset.get_path())
+        assert list(fastavro.reader(io.BytesIO(raw))) == [{"id": "a"}, {"id": "b"}]
+
+        PersistentStore._instances.clear()
+        store = PersistentStore(asset, storage)
+        store.retrieve()
+        assert store._local_path is not None
+        local_path = store._local_path
+        assert list(fastavro.reader(local_path.open("rb"))) == [{"id": "a"}, {"id": "b"}]
+
+        # Second retrieve with an unchanged etag must short-circuit (same file).
+        store.retrieve()
+        assert store._local_path == local_path
+
+        store.cleanup()
+        assert store._local_path is None
+        assert not local_path.exists()
+
+    def test_retrieve_missing_raises_asset_not_found(self) -> None:
+        with pytest.raises(AssetNotFoundError, match=r"Asset 'ghost' not found"):
+            PersistentStore(PersistentStoreAsset("ghost"), MemoryStorage()).retrieve()
+
+
+class TestStoreAssetAsync:
+    async def test_store_asset_async_round_trip(self, test_tmp_dir: Path) -> None:
+        schema = {"type": "record", "name": "Async", "fields": [{"name": "id", "type": "string"}]}
+        schema_path = test_tmp_dir / "schemas" / "async-asset.v1.avro.json"
+        schema_path.write_text(json.dumps(schema))
+
+        catalog = Catalog(
+            storage=MemoryStorage(),
+            schema_store=LocalSchemaStore(test_tmp_dir / "schemas"),
+            queue=InMemoryQueue(),
+        )
+        asset = DataLakeAsset("async-asset", utcnow())
+        data = [{"id": "a"}, {"id": "b"}]
+        await catalog.store_asset_async(asset, data, notify=True, schema_path=schema_path.as_posix())
+
+        assert list(catalog.retrieve_asset(asset)) == data
+        queue = catalog.queue
+        assert isinstance(queue, InMemoryQueue)
+        assert len(queue._messages) == 1
+
+
+class TestRepartition:
+    async def test_repartition_data_lake_asset_by_day(self, tmp_path: Path) -> None:
+        schema_dir = tmp_path / "schemas" / "data_lake"
+        schema_dir.mkdir(parents=True)
+        (schema_dir / "repart.v1.avro.json").write_text(json.dumps(_TS_SCHEMA))
+
+        catalog = Catalog(
+            storage=MemoryStorage(),
+            schema_store=LocalSchemaStore(tmp_path / "schemas"),
+            queue=InMemoryQueue(),
+        )
+        day_one = datetime.datetime(2025, 1, 1, 8, tzinfo=datetime.timezone.utc)
+        day_two = datetime.datetime(2025, 1, 2, 9, tzinfo=datetime.timezone.utc)
+        records = [
+            {"id": "a", "timestamp": day_one},
+            {"id": "b", "timestamp": day_one.replace(hour=20)},
+            {"id": "c", "timestamp": day_two},
+        ]
+        source_asset = DataLakeAsset("repart", day_one)
+
+        await catalog.repartition(source_asset, "d", date_attribute="timestamp", data=records)
+
+        partitions = sorted(catalog.iter_datalake_partitions("repart"), key=lambda asset: asset.date)
+        assert [p.date for p in partitions] == [
+            datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc),
+            datetime.datetime(2025, 1, 2, tzinfo=datetime.timezone.utc),
+        ]
+        first_day = list(catalog.retrieve_asset(partitions[0]))
+        assert {row["id"] for row in first_day} == {"a", "b"}
+        second_day = list(catalog.retrieve_asset(partitions[1]))
+        assert {row["id"] for row in second_day} == {"c"}

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -1,35 +1,29 @@
 import datetime
+import io
 import json
-import tempfile
-from collections.abc import Iterator
+import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
+from uuid import uuid4
 
 import boto3
 import fastavro
 import pytest
 
+from hyperion.adapters.storage.filesystem import FilesystemStorage
+from hyperion.adapters.storage.memory import MemoryStorage
+from hyperion.adapters.storage.s3 import S3Storage
 from hyperion.catalog.catalog import AssetNotFoundError, Catalog
 from hyperion.catalog.schema import LocalSchemaStore
 from hyperion.dateutils import TimeResolution, assure_timezone, quantize_datetime, utcnow
-from hyperion.entities.catalog import AssetProtocol, AssetType, DataLakeAsset, FeatureAsset, PersistentStoreAsset
+from hyperion.domain.assets import AssetProtocol, DataLakeAsset, FeatureAsset
 from hyperion.infrastructure.cache import LocalFileCache
 from hyperion.infrastructure.message_queue import (
     ArrivalEvent,
     DataLakeArrivalMessage,
     InMemoryQueue,
 )
-
-if TYPE_CHECKING:
-    from mypy_boto3_s3.client import S3Client
-
-DATA_LAKE_BUCKET = "test-data-lake"
-FEATURE_STORE_BUCKET = "test-feature-store"
-PERSISTENT_STORE_BUCKET = "test-persistent-store"
-PREFIXED_BUCKET = "test-prefixed-store"
-DATA_LAKE_PREFIX = "data-lake/"
-FEATURE_STORE_PREFIX = "feature-store/"
-PERSISTENT_STORE_PREFIX = "persistent-store/"
+from hyperion.ports.storage import StoragePort
 
 USERS_PARTITION_DATE = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
 PLACES_PARTITION_DATES = (
@@ -41,111 +35,90 @@ SUPERFEATURE_PARTITION_DATES = [
     quantize_datetime(SUPERFEATURE_DATE_START + datetime.timedelta(days=day), "1d") for day in range(0, 7)
 ]
 
-
-@pytest.fixture(name="s3client", scope="module")
-def _s3client(_moto_server: None) -> "S3Client":
-    s3 = boto3.client("s3")
-    buckets = (DATA_LAKE_BUCKET, FEATURE_STORE_BUCKET, PERSISTENT_STORE_BUCKET, PREFIXED_BUCKET)
-    for bucket in buckets:
-        s3.create_bucket(Bucket=bucket)
-    return s3
+# Backend matrix the catalog suite runs against (DDD refactor Step 5 / F1). The
+# same tests exercise an in-memory store, a local filesystem store, an
+# S3 store (moto) and a cache-wrapped store -- proving the restored
+# "Catalog on local disk" promise and S3 parity from one test body.
+CATALOG_BACKENDS = ["memory", "filesystem", "s3", "cached"]
 
 
-def _create_fake_asset(
-    asset_name: str, s3client: "S3Client", partition_date: datetime.datetime, asset_type: AssetType, avro_file: Path
-) -> None:
-    bucket: str
-    prefix: str
-    match asset_type:
-        case "data_lake":
-            bucket = DATA_LAKE_BUCKET
-            prefix = DATA_LAKE_PREFIX
-        case "feature":
-            bucket = FEATURE_STORE_BUCKET
-            prefix = FEATURE_STORE_PREFIX
-        case "persistent_store":
-            raise NotImplementedError("Testing persistent store assets is not implemented yet.")
-            # bucket = PERSISTENT_STORE_BUCKET
-            # prefix = PERSISTENT_STORE_PREFIX
-        case _:
-            raise ValueError(f"Unsupported asset type {asset_type!r}.")
-    partition_name = "partition_date" if asset_type == "feature" else "date"
-    path = f"{asset_name}/{partition_name}={partition_date.isoformat()}/v1.avro"
-    avro_file = avro_file.resolve()
-    s3client.upload_file(Filename=avro_file.as_posix(), Bucket=bucket, Key=path)
-    s3client.upload_file(Filename=avro_file.as_posix(), Bucket=PREFIXED_BUCKET, Key=f"{prefix}{path}")
+def _seed_storage(storage: StoragePort, data_dir: Path) -> None:
+    """Put the fake data lake + feature assets into ``storage``.
 
-
-def _create_fake_data_lake(data_dir: Path, s3client: "S3Client") -> None:
-    _create_fake_asset("users", s3client, USERS_PARTITION_DATE, "data_lake", data_dir / "assets/users.v1.avro")
+    Storage-agnostic replacement for the old direct-to-S3 seeding: the catalog
+    now addresses objects by ``asset.get_path()`` regardless of backend.
+    """
+    storage.put(
+        DataLakeAsset("users", USERS_PARTITION_DATE).get_path(),
+        (data_dir / "assets/users.v1.avro").read_bytes(),
+    )
     for place_partition_date in PLACES_PARTITION_DATES:
-        _create_fake_asset("places", s3client, place_partition_date, "data_lake", data_dir / "assets/places.v1.avro")
-
-
-def _create_fake_feature_store(data_dir: Path, s3client: "S3Client") -> None:
-    for feature_file in (data_dir / "assets").glob("superfeature.*.v1.avro"):
+        storage.put(
+            DataLakeAsset("places", place_partition_date).get_path(),
+            (data_dir / "assets/places.v1.avro").read_bytes(),
+        )
+    for feature_file in sorted((data_dir / "assets").glob("superfeature.*.v1.avro")):
         partition_date_str = feature_file.name.split(".")[1]
         partition_date = assure_timezone(datetime.datetime.fromisoformat(partition_date_str))
-        _create_fake_asset("superfeature.1d", s3client, partition_date, "feature", feature_file)
+        storage.put(
+            FeatureAsset("superfeature", partition_date, "1d").get_path(),
+            feature_file.read_bytes(),
+        )
 
 
-@pytest.fixture(scope="module")
-def _test_data(data_dir: Path, s3client: "S3Client") -> None:
-    _create_fake_data_lake(data_dir, s3client)
-    _create_fake_feature_store(data_dir, s3client)
+def _make_storage(kind: str, tmp_path_factory: pytest.TempPathFactory) -> StoragePort:
+    if kind == "memory" or kind == "cached":
+        return MemoryStorage()
+    if kind == "filesystem":
+        return FilesystemStorage(tmp_path_factory.mktemp("fs-catalog"))
+    if kind == "s3":
+        bucket = f"hyperion-catalog-test-{uuid4().hex}"
+        boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=bucket)
+        return S3Storage(bucket)
+    raise ValueError(f"Unknown catalog backend {kind!r}.")
 
 
 @pytest.fixture(name="test_tmp_dir", scope="session")
-def _test_tmp_dir(data_dir: Path) -> Iterator[Path]:
-    with tempfile.TemporaryDirectory(prefix="tmphyp_") as tmpdir:
-        tmp_path = Path(tmpdir)
-        (tmp_path / "schemas").mkdir(parents=True)
-        (tmp_path / "cache").mkdir(parents=True)
-        (tmp_path / "schemas/custom_schema.json").write_text((data_dir / "assets/custom_schema.json").read_text())
-        yield tmp_path
-
-
-@pytest.fixture(name="default_catalog", scope="session")
-def _default_catalog(test_tmp_dir: Path) -> Catalog:
-    return Catalog(
-        data_lake_bucket=DATA_LAKE_BUCKET,
-        feature_store_bucket=FEATURE_STORE_BUCKET,
-        persistent_store_bucket=PERSISTENT_STORE_BUCKET,
-        schema_store=LocalSchemaStore(test_tmp_dir / "schemas"),
-    )
-
-
-@pytest.fixture(name="prefixed_catalog", scope="session")
-def _prefixed_catalog(test_tmp_dir: Path) -> Catalog:
-    return Catalog(
-        data_lake_bucket=PREFIXED_BUCKET,
-        feature_store_bucket=PREFIXED_BUCKET,
-        persistent_store_bucket=PREFIXED_BUCKET,
-        data_lake_prefix=DATA_LAKE_PREFIX,
-        feature_store_prefix=FEATURE_STORE_PREFIX,
-        persistent_store_prefix=PERSISTENT_STORE_PREFIX,
-        schema_store=LocalSchemaStore(test_tmp_dir / "schemas"),
-    )
-
-
-@pytest.fixture(name="cached_catalog", scope="session")
-def _cached_catalog(test_tmp_dir: Path) -> Catalog:
-    return Catalog(
-        data_lake_bucket=DATA_LAKE_BUCKET,
-        feature_store_bucket=FEATURE_STORE_BUCKET,
-        persistent_store_bucket=PERSISTENT_STORE_BUCKET,
-        cache=LocalFileCache("test", default_ttl=3600, root_path=test_tmp_dir / "cache"),
-        schema_store=LocalSchemaStore(test_tmp_dir / "schemas"),
-    )
+def _test_tmp_dir(data_dir: Path, tmp_path_factory: pytest.TempPathFactory) -> Path:
+    tmp_path = tmp_path_factory.mktemp("hyp_catalog")
+    (tmp_path / "schemas").mkdir(parents=True)
+    (tmp_path / "schemas/custom_schema.json").write_text((data_dir / "assets/custom_schema.json").read_text())
+    return tmp_path
 
 
 @pytest.fixture(name="catalog")
 def _catalog(
-    default_catalog: Catalog, prefixed_catalog: Catalog, cached_catalog: Catalog, request: pytest.FixtureRequest
+    request: pytest.FixtureRequest,
+    data_dir: Path,
+    test_tmp_dir: Path,
+    tmp_path_factory: pytest.TempPathFactory,
+    _moto_server: None,
 ) -> Catalog:
-    return {"default_catalog": default_catalog, "prefixed_catalog": prefixed_catalog, "cached_catalog": cached_catalog}[
-        request.param
-    ]
+    kind = request.param
+    storage = _make_storage(kind, tmp_path_factory)
+    _seed_storage(storage, data_dir)
+    cache = (
+        LocalFileCache("test", default_ttl=3600, root_path=tmp_path_factory.mktemp("cache"))
+        if kind == "cached"
+        else None
+    )
+    return Catalog(
+        storage=storage,
+        cache=cache,
+        schema_store=LocalSchemaStore(test_tmp_dir / "schemas"),
+        queue=InMemoryQueue(),
+    )
+
+
+@pytest.fixture
+def queue_aware_catalog(test_tmp_dir: Path) -> Catalog:
+    # Queue notification behaviour is storage-independent; a single in-memory
+    # backend keeps these tests fast and deterministic.
+    return Catalog(
+        storage=MemoryStorage(),
+        schema_store=LocalSchemaStore(test_tmp_dir / "schemas"),
+        queue=InMemoryQueue(),
+    )
 
 
 def _get_test_asset_fields(asset_name: str, data_dir: Path) -> set[str]:
@@ -175,44 +148,22 @@ def _get_test_asset_size(asset_name: str, data_dir: Path) -> int:
     return avro_file.stat().st_size
 
 
-@pytest.mark.parametrize(
-    ("asset", "expected_bucket", "expected_prefix"),
-    [
-        (DataLakeAsset("test", utcnow()), DATA_LAKE_BUCKET, DATA_LAKE_PREFIX),
-        (FeatureAsset("test", utcnow(), "1d"), FEATURE_STORE_BUCKET, FEATURE_STORE_PREFIX),
-        (PersistentStoreAsset("test"), PERSISTENT_STORE_BUCKET, PERSISTENT_STORE_PREFIX),
-    ],
-)
-def test_store_config(
-    default_catalog: Catalog,
-    prefixed_catalog: Catalog,
-    asset: AssetProtocol,
-    expected_bucket: str,
-    expected_prefix: str,
-) -> None:
-    store_config = default_catalog.get_store_config(asset)
-    prefixed_config = prefixed_catalog.get_store_config(asset)
-
-    assert store_config["bucket"] == expected_bucket
-    assert store_config["prefix"] == ""
-
-    assert prefixed_config["bucket"] == PREFIXED_BUCKET
-    assert prefixed_config["prefix"] == expected_prefix
-
-    assert f"{asset.name}" in asset.get_path()
-    assert "v1.avro" in asset.get_path()
-    assert asset.get_path(expected_prefix).startswith(f"{expected_prefix}{asset.name}")
-
-    if isinstance(asset, FeatureAsset):
-        assert str(asset.resolution) in asset.get_path()
+def _read_avro_via_storage(catalog: Catalog, asset: AssetProtocol) -> tuple[list[Any], dict[str, Any]]:
+    """Round-trip helper: pull an avro blob straight out of the catalog's storage and decode it."""
+    raw = catalog._resolve_storage(asset).get(asset.get_path())
+    reader = fastavro.reader(io.BytesIO(raw))
+    records: list[Any] = list(reader)
+    metadata: dict[str, Any] = dict(reader.metadata)
+    return records, metadata
 
 
-@pytest.mark.parametrize("catalog", ["default_catalog", "prefixed_catalog", "cached_catalog"], indirect=True)
-@pytest.mark.usefixtures("_test_data")
+@pytest.mark.parametrize("catalog", CATALOG_BACKENDS, indirect=True)
 class TestCatalog:
     def test_iter_datalake_partitions(self, catalog: Catalog) -> None:
+        # iter_datalake_partitions yields in storage-listing order, which is not
+        # part of its contract (ordered access is find_latest_datalake_partition).
         assert list(catalog.iter_datalake_partitions("users")) == [DataLakeAsset("users", USERS_PARTITION_DATE)]
-        assert list(catalog.iter_datalake_partitions("places")) == [
+        assert sorted(catalog.iter_datalake_partitions("places"), key=lambda asset: asset.date) == [
             DataLakeAsset("places", place_partition_date) for place_partition_date in PLACES_PARTITION_DATES
         ]
 
@@ -297,49 +248,148 @@ class TestCatalog:
 
 
 # -----------------------------------------------------------------------------
-# Contract-hardening tests (Group B1 of the DDD refactor prep plan).
-#
-# These pin behaviours that today only exist implicitly. After the refactor adds
-# `StoragePort`, the same tests will be parametrized over `S3Storage(moto)` and
-# `FilesystemStorage(tmp_path)` (refactor Step 5) — write them so that
-# parametrize axis can be added without rewrites.
+# Constructor-inversion contract (DDD refactor F1 / Step 5).
 # -----------------------------------------------------------------------------
 
 
-@pytest.fixture
-def queue_aware_catalog(test_tmp_dir: Path, s3client: "S3Client") -> Catalog:
-    # Reuse the catalog buckets from the module fixture but inject an in-memory
-    # queue so we can observe arrival notifications without touching SQS.
-    return Catalog(
-        data_lake_bucket=DATA_LAKE_BUCKET,
-        feature_store_bucket=FEATURE_STORE_BUCKET,
-        persistent_store_bucket=PERSISTENT_STORE_BUCKET,
-        schema_store=LocalSchemaStore(test_tmp_dir / "schemas"),
-        queue=InMemoryQueue(),
+class TestStorageRouting:
+    """`Catalog` accepts a single port (one store for everything) or a
+    per-asset-type mapping (how `from_config()` keeps today's 3-bucket layout).
+    """
+
+    def test_single_port_serves_every_asset_type(self, test_tmp_dir: Path) -> None:
+        storage = MemoryStorage()
+        catalog = Catalog(storage=storage, schema_store=LocalSchemaStore(test_tmp_dir / "schemas"))
+        assert catalog._resolve_storage(DataLakeAsset) is storage
+        assert catalog._resolve_storage(FeatureAsset) is storage
+        assert catalog._resolve_storage(DataLakeAsset("x", utcnow())) is storage
+
+    def test_mapping_routes_per_asset_type(self, test_tmp_dir: Path) -> None:
+        data_lake = MemoryStorage()
+        feature = MemoryStorage()
+        persistent = MemoryStorage()
+        catalog = Catalog(
+            storage={"data_lake": data_lake, "feature": feature, "persistent_store": persistent},
+            schema_store=LocalSchemaStore(test_tmp_dir / "schemas"),
+        )
+
+        schema = {"type": "record", "name": "R", "fields": [{"name": "id", "type": "string"}]}
+        schema_path = test_tmp_dir / "schemas" / "routing.v1.avro.json"
+        schema_path.write_text(json.dumps(schema))
+
+        dl_asset = DataLakeAsset("routed", utcnow())
+        catalog.store_asset(dl_asset, [{"id": "a"}], notify=False, schema_path=schema_path.as_posix())
+
+        # Landed only in the data-lake backend, nowhere else.
+        assert dl_asset.get_path() in data_lake._store
+        assert feature._store == {}
+        assert persistent._store == {}
+        assert list(catalog.retrieve_asset(dl_asset)) == [{"id": "a"}]
+
+    def test_incomplete_mapping_is_rejected(self, test_tmp_dir: Path) -> None:
+        with pytest.raises(ValueError, match=r"missing adapters for asset types"):
+            Catalog(
+                storage={"data_lake": MemoryStorage()},
+                schema_store=LocalSchemaStore(test_tmp_dir / "schemas"),
+            )
+
+    def test_old_bucket_kwargs_are_a_hard_break(self, test_tmp_dir: Path) -> None:
+        # The pre-1.0 bucket/prefix constructor is gone; only from_config() (or an
+        # explicit StoragePort) is supported now.
+        with pytest.raises(TypeError):
+            Catalog(  # type: ignore[call-arg]
+                data_lake_bucket="dl",
+                feature_store_bucket="fs",
+                persistent_store_bucket="ps",
+            )
+
+
+class TestLocalDiskPromise:
+    """DoD: a `[catalog]`-only consumer can run `Catalog` against local disk
+    (no `[aws]`).
+    """
+
+    def test_filesystem_round_trip(self, tmp_path: Path) -> None:
+        # LocalSchemaStore resolves schemas at <root>/<asset_type>/<name>.v<n>.avro.json.
+        schema_dir = tmp_path / "schemas" / "data_lake"
+        schema_dir.mkdir(parents=True)
+        schema = {"type": "record", "name": "Local", "fields": [{"name": "id", "type": "string"}]}
+        (schema_dir / "diskasset.v1.avro.json").write_text(json.dumps(schema))
+
+        catalog = Catalog(
+            storage=FilesystemStorage(tmp_path / "data"),
+            schema_store=LocalSchemaStore(tmp_path / "schemas"),
+        )
+        asset = DataLakeAsset("diskasset", datetime.datetime(2025, 3, 1, tzinfo=datetime.timezone.utc))
+        records = [{"id": "one"}, {"id": "two"}]
+        catalog.store_asset(asset, records, notify=False)
+
+        assert (tmp_path / "data" / asset.get_path()).is_file()
+        assert list(catalog.retrieve_asset(asset)) == records
+        assert catalog.find_latest_datalake_partition("diskasset") == asset
+
+
+@pytest.mark.usefixtures("_moto_server")
+def test_from_config_uses_correct_per_store_prefixes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`from_config()` must wire the feature store with the *feature* prefix.
+
+    Pins the Step 5 bug-fix: the pre-refactor `from_config()` fed the data-lake
+    prefix into the feature store.
+    """
+    import types
+
+    fake_config = types.SimpleNamespace(
+        data_lake_bucket="dl-bucket",
+        feature_store_bucket="fs-bucket",
+        persistent_store_bucket="ps-bucket",
+        data_lake_prefix="dl",
+        feature_store_prefix="fs",
+        persistent_store_prefix="ps",
     )
+    monkeypatch.setattr("hyperion.catalog.catalog.storage_config", fake_config)
+    # from_config() builds a default SchemaStore from env; stub it out so this
+    # test stays focused on storage wiring.
+    monkeypatch.setattr("hyperion.catalog.catalog.SchemaStore", types.SimpleNamespace(from_config=lambda: object()))
+
+    catalog = Catalog.from_config()
+
+    feature_storage = catalog._resolve_storage(FeatureAsset)
+    assert isinstance(feature_storage, S3Storage)
+    assert feature_storage._bucket == "fs-bucket"
+    assert feature_storage._prefix == "fs/"  # not "dl/" -- the fixed bug
+    data_lake_storage = catalog._resolve_storage(DataLakeAsset)
+    assert isinstance(data_lake_storage, S3Storage)
+    assert data_lake_storage._prefix == "dl/"
 
 
-def _read_avro_via_s3(bucket: str, key: str) -> tuple[list[Any], dict[str, Any]]:
-    """Round-trip helper: pull an avro blob out of S3 and decode it directly."""
-    import io
+def test_catalog_module_has_no_direct_boto3_or_fastavro_imports() -> None:
+    """S5 deliverable: `catalog.py` itself no longer references boto3/fastavro.
 
-    s3 = boto3.client("s3")
-    response = s3.get_object(Bucket=bucket, Key=key)
-    body = response["Body"].read()
+    (A transitive boto3 still arrives via `infrastructure.message_queue`; that
+    module's concretes relocate in S6, so a `sys.modules` check is premature.)
+    """
+    source = Path(Catalog.__module__.replace(".", "/") + ".py")
+    if not source.exists():  # pragma: no cover - import layout fallback
+        import hyperion.catalog.catalog as catalog_module
 
-    reader = fastavro.reader(io.BytesIO(body))
-    records: list[Any] = list(reader)
-    metadata: dict[str, Any] = dict(reader.metadata)
-    return records, metadata
+        source = Path(catalog_module.__file__)
+    text = source.read_text()
+    offenders = re.findall(r"^(?:import|from)\s+(?:boto3|botocore|fastavro)\b.*$", text, flags=re.MULTILINE)
+    offenders += re.findall(r"^.*\bS3Client\b.*$", text, flags=re.MULTILINE)
+    assert offenders == [], f"catalog.py must not import boto3/fastavro/S3Client directly: {offenders}"
+
+
+# -----------------------------------------------------------------------------
+# Contract-hardening tests (avro byte-contract, queue notifications, key parsing).
+# -----------------------------------------------------------------------------
 
 
 class TestAvroRoundtrip:
-    """Lock the avro encode/decode contract so refactor Step 5 (StoragePort + AvroSerializer
-    extraction) can be checked for byte-level parity.
+    """Lock the avro encode/decode contract so the extracted `AvroSerializer`
+    keeps byte-level parity with the pre-refactor inline implementation.
     """
 
     def test_primitive_types_roundtrip(self, queue_aware_catalog: Catalog, test_tmp_dir: Path) -> None:
-        # Write a one-off schema that exercises strings, longs, doubles, booleans, nulls.
         schema = {
             "type": "record",
             "name": "Primitives",
@@ -364,9 +414,7 @@ class TestAvroRoundtrip:
         retrieved = list(queue_aware_catalog.retrieve_asset(asset))
         assert retrieved == data
 
-    def test_array_and_record_types_roundtrip(
-        self, queue_aware_catalog: Catalog, test_tmp_dir: Path
-    ) -> None:
+    def test_array_and_record_types_roundtrip(self, queue_aware_catalog: Catalog, test_tmp_dir: Path) -> None:
         schema = {
             "type": "record",
             "name": "Composite",
@@ -395,10 +443,7 @@ class TestAvroRoundtrip:
         retrieved = list(queue_aware_catalog.retrieve_asset(asset))
         assert retrieved == data
 
-    def test_metadata_written_to_avro(
-        self, queue_aware_catalog: Catalog, test_tmp_dir: Path
-    ) -> None:
-        # The catalog writes the asset's to_metadata() into avro's metadata block.
+    def test_metadata_written_to_avro(self, queue_aware_catalog: Catalog, test_tmp_dir: Path) -> None:
         schema = {
             "type": "record",
             "name": "MetadataCheck",
@@ -409,14 +454,14 @@ class TestAvroRoundtrip:
 
         date = datetime.datetime(2025, 1, 2, tzinfo=datetime.timezone.utc)
         asset = DataLakeAsset("metadata-check", date)
-        queue_aware_catalog.store_asset(
-            asset, [{"id": "x"}], notify=False, schema_path=schema_path.as_posix()
-        )
+        queue_aware_catalog.store_asset(asset, [{"id": "x"}], notify=False, schema_path=schema_path.as_posix())
 
-        _, metadata = _read_avro_via_s3(DATA_LAKE_BUCKET, asset.get_path())
-        # fastavro returns metadata keys as bytes.
-        decoded = {k.decode() if isinstance(k, bytes) else k: v.decode() if isinstance(v, bytes) else v
-                   for k, v in metadata.items()}
+        _, metadata = _read_avro_via_storage(queue_aware_catalog, asset)
+        # fastavro returns metadata keys/values as bytes.
+        decoded = {
+            k.decode() if isinstance(k, bytes) else k: v.decode() if isinstance(v, bytes) else v
+            for k, v in metadata.items()
+        }
         assert decoded.get("name") == "metadata-check"
         assert decoded.get("schema_version") == "1"
         assert decoded.get("date") == date.isoformat()
@@ -431,9 +476,7 @@ class TestQueueNotification:
         schema_path.write_text(json.dumps(schema))
 
         asset = DataLakeAsset("notify-check", utcnow())
-        queue_aware_catalog.store_asset(
-            asset, [{"id": "x"}], notify=True, schema_path=schema_path.as_posix()
-        )
+        queue_aware_catalog.store_asset(asset, [{"id": "x"}], notify=True, schema_path=schema_path.as_posix())
 
         queue = queue_aware_catalog.queue
         assert isinstance(queue, InMemoryQueue)
@@ -444,9 +487,7 @@ class TestQueueNotification:
         assert message.event == ArrivalEvent.ARRIVED
         assert message.schema_path == schema_path.as_posix()
 
-    def test_notify_false_skips_message(
-        self, queue_aware_catalog: Catalog, test_tmp_dir: Path
-    ) -> None:
+    def test_notify_false_skips_message(self, queue_aware_catalog: Catalog, test_tmp_dir: Path) -> None:
         schema = {"type": "record", "name": "X", "fields": [{"name": "id", "type": "string"}]}
         schema_path = test_tmp_dir / "schemas" / "notify-false.v1.avro.json"
         schema_path.write_text(json.dumps(schema))
@@ -455,16 +496,10 @@ class TestQueueNotification:
         queue = queue_aware_catalog.queue
         assert isinstance(queue, InMemoryQueue)
         before = len(queue._messages)
-        queue_aware_catalog.store_asset(
-            asset, [{"id": "x"}], notify=False, schema_path=schema_path.as_posix()
-        )
+        queue_aware_catalog.store_asset(asset, [{"id": "x"}], notify=False, schema_path=schema_path.as_posix())
         assert len(queue._messages) == before
 
-    def test_non_datalake_asset_does_not_notify(
-        self, queue_aware_catalog: Catalog, test_tmp_dir: Path
-    ) -> None:
-        # FeatureAsset / PersistentStoreAsset should not trigger queue notifications even
-        # when notify=True (per `_notify_asset_arrival`).
+    def test_non_datalake_asset_does_not_notify(self, queue_aware_catalog: Catalog, test_tmp_dir: Path) -> None:
         schema = {"type": "record", "name": "X", "fields": [{"name": "id", "type": "string"}]}
         schema_path = test_tmp_dir / "schemas" / "feature-no-notify.v1.avro.json"
         schema_path.write_text(json.dumps(schema))
@@ -473,75 +508,57 @@ class TestQueueNotification:
         queue = queue_aware_catalog.queue
         assert isinstance(queue, InMemoryQueue)
         before = len(queue._messages)
-        queue_aware_catalog.store_asset(
-            feature_asset, [{"id": "x"}], notify=True, schema_path=schema_path.as_posix()
-        )
+        queue_aware_catalog.store_asset(feature_asset, [{"id": "x"}], notify=True, schema_path=schema_path.as_posix())
         assert len(queue._messages) == before
 
 
+@pytest.mark.parametrize("catalog", CATALOG_BACKENDS, indirect=True)
 class TestPartitionIterationRegex:
-    """Pins the key-parsing contract of `iter_datalake_partitions`. Refactor F1
-    (StoragePort) hands over the key iteration to the adapter; the regex must continue
-    to skip non-conforming keys and parse valid ones.
+    """Pins the key-parsing contract of `iter_datalake_partitions`. The adapter
+    now owns key iteration; the regex must still skip non-conforming keys.
     """
 
-    def test_multiple_versions_for_same_date(self, default_catalog: Catalog, test_tmp_dir: Path) -> None:
+    def test_multiple_versions_for_same_date(self, catalog: Catalog, test_tmp_dir: Path) -> None:
         schema = {"type": "record", "name": "X", "fields": [{"name": "id", "type": "string"}]}
         schema_path = test_tmp_dir / "schemas" / "multiver.v1.avro.json"
         schema_path.write_text(json.dumps(schema))
-        # Write the same asset name with two schema versions on the same date.
         date = datetime.datetime(2025, 6, 1, tzinfo=datetime.timezone.utc)
-        default_catalog.store_asset(
+        catalog.store_asset(
             DataLakeAsset("multiver", date, schema_version=1),
-            [{"id": "v1"}], notify=False, schema_path=schema_path.as_posix(),
+            [{"id": "v1"}],
+            notify=False,
+            schema_path=schema_path.as_posix(),
         )
-        default_catalog.store_asset(
+        catalog.store_asset(
             DataLakeAsset("multiver", date, schema_version=2),
-            [{"id": "v2"}], notify=False, schema_path=schema_path.as_posix(),
+            [{"id": "v2"}],
+            notify=False,
+            schema_path=schema_path.as_posix(),
         )
 
-        partitions = list(default_catalog.iter_datalake_partitions("multiver"))
+        partitions = list(catalog.iter_datalake_partitions("multiver"))
         versions = sorted(p.schema_version for p in partitions)
         assert versions == [1, 2]
 
-    def test_skips_keys_with_invalid_filename(
-        self, default_catalog: Catalog, s3client: "S3Client"
-    ) -> None:
-        # Drop a junk key under the asset prefix and verify iter_datalake_partitions
-        # silently skips it.
-        s3client.put_object(
-            Bucket=DATA_LAKE_BUCKET,
-            Key="junk-asset/date=2025-07-01T00:00:00+00:00/not-an-avro-file.txt",
-            Body=b"junk",
+    def test_skips_keys_with_invalid_filename(self, catalog: Catalog) -> None:
+        catalog._resolve_storage(DataLakeAsset).put(
+            "junk-asset/date=2025-07-01T00:00:00+00:00/not-an-avro-file.txt", b"junk"
         )
-        # No partitions should match since the filename doesn't fit the version regex.
-        partitions = list(default_catalog.iter_datalake_partitions("junk-asset"))
+        partitions = list(catalog.iter_datalake_partitions("junk-asset"))
         assert partitions == []
 
-    def test_skips_keys_with_wrong_structure(
-        self, default_catalog: Catalog, s3client: "S3Client"
-    ) -> None:
-        # A key with fewer than 3 path segments must be skipped (no exception).
-        s3client.put_object(
-            Bucket=DATA_LAKE_BUCKET,
-            Key="bad-shape-asset/v1.avro",
-            Body=b"junk",
-        )
-        partitions = list(default_catalog.iter_datalake_partitions("bad-shape-asset"))
+    def test_skips_keys_with_wrong_structure(self, catalog: Catalog) -> None:
+        catalog._resolve_storage(DataLakeAsset).put("bad-shape-asset/v1.avro", b"junk")
+        partitions = list(catalog.iter_datalake_partitions("bad-shape-asset"))
         assert partitions == []
 
 
+@pytest.mark.parametrize("catalog", CATALOG_BACKENDS, indirect=True)
 class TestFeatureStorePartitionQuantization:
-    @pytest.mark.usefixtures("_test_data")
-    def test_skips_missing_partitions(self, default_catalog: Catalog) -> None:
-        # Span a range that is wider than what's seeded; missing partitions must be
-        # silently skipped, not raised.
+    def test_skips_missing_partitions(self, catalog: Catalog) -> None:
         date_from = SUPERFEATURE_DATE_START - datetime.timedelta(days=14)
         date_to = SUPERFEATURE_PARTITION_DATES[-1] + datetime.timedelta(days=14)
         partitions = list(
-            default_catalog.iter_feature_store_partitions(
-                "superfeature", TimeResolution(1, "d"), date_from, date_to
-            )
+            catalog.iter_feature_store_partitions("superfeature", TimeResolution(1, "d"), date_from, date_to)
         )
-        # Only the seeded partitions are returned; the surrounding dates aren't.
         assert {p.partition_date for p in partitions} == set(SUPERFEATURE_PARTITION_DATES)


### PR DESCRIPTION
## Summary

S5 of the DDD refactor (epic #137) — the core of **F1**. Inverts `Catalog`'s storage dependency onto the S4 `StoragePort` and extracts all fastavro use into a serialization adapter. `catalog.py` no longer references boto3/`S3Client`/`botocore`/fastavro at module scope, so `[catalog]` works **without `[aws]`** (filesystem-backed catalog).

Closes #130. Non-bumping (`refactor:`) — no `release/*` PR. Depends on S2/S4 (both on `master`).

## Changes

- `Catalog.__init__` now takes `storage: StoragePort | Mapping[AssetType, StoragePort]` instead of the `*_bucket`/`*_prefix` kwargs. A single port serves every asset type; a per-type mapping preserves today's per-bucket S3 layout. Per-store prefixes move into the `S3Storage` adapter. Removed surface: `StoreBucketConfig`, `get_store_config()`, the `s3_client` property and the bucket/prefix attributes (no external callers — grep-confirmed; consumers reach `Catalog` only via `from_config()`).
- New `hyperion/adapters/serialization/avro.py` — `AvroSerializer` + `AvroStreamWriter` Protocol. The only module importing fastavro; gated behind the future `[catalog]` extra with a clear ImportError. `Catalog` default-constructs it when no serializer is injected.
- `ObjectNotFoundError` (StoragePort contract) → `AssetNotFoundError`. `PersistentStore`/`WritablePersistentStore`/`AssetRepartitioner` rewired onto `StoragePort` + the serializer.

## ⚠️ Behaviour call-outs (for the S11 CHANGELOG migration table)

1. **One non-additive break (mitigated):** the `Catalog(data_lake_bucket=…, …)` constructor is gone — old bucket/prefix kwargs now raise `TypeError`. `Catalog.from_config()` is kept and builds the **same per-bucket S3 layout** as before, so every shipping consumer (all use `from_config()`) is unaffected.
2. **Pre-existing bug fixed:** `from_config()` was wiring the **feature store** with the *data lake* prefix. It now correctly uses `feature_store_prefix`. Env configs where `feature_store_prefix != data_lake_prefix` will now resolve to the correct keys (was previously writing/reading feature assets under the data-lake prefix).
3. Catalog cache keys changed from `"{bucket}:{path}"` to `"{asset_type}:{path}"` → at most a one-time miss on the opt-in TTL cache.

## Tests

- `tests/catalog/test_catalog.py` rewritten: the whole suite is parametrized over `MemoryStorage`, `FilesystemStorage(tmp_path)`, `S3Storage(moto)` and a cache-wrapped variant — proving the restored **local-disk promise** and S3 parity from one test body.
- Added: storage-routing (single vs per-type mapping vs incomplete), hard-break `TypeError`, local-disk round-trip, `from_config()` prefix-bugfix pin, `catalog.py`-has-no-direct-boto3/fastavro source guard, and `AvroSerializer` unit tests.
- Full suite green (479 passed, 1 pre-existing xfail) py3.13 locally; `mypy`, `ruff`, `pre-commit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)