### PR TITLE
refactor(adapters): relocate cache/keyval/queue/secrets/schema impls

### DIFF
--- a/hyperion/adapters/cache/__init__.py
+++ b/hyperion/adapters/cache/__init__.py
@@ -1,0 +1,5 @@
+"""Cache adapters. Import the concrete module you need explicitly.
+
+``memory`` and ``filesystem`` are lite; ``dynamodb`` requires boto3 (``[aws]``).
+No eager re-exports here -- touching this namespace must stay boto3-free.
+"""

--- a/hyperion/adapters/cache/dynamodb.py
+++ b/hyperion/adapters/cache/dynamodb.py
@@ -1,0 +1,87 @@
+"""DynamoDB-backed :class:`Cache` adapter (requires boto3 -- ``[aws]``)."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, cast
+
+import boto3
+
+from hyperion.log import get_logger
+from hyperion.ports.cache import DEFAULT_TTL_SECONDS, Cache, CachingError
+
+DYNAMODB_MAX_LENGTH = 65535
+
+logger = get_logger("cache")
+
+
+class DynamoDBCache(Cache):
+    """A DynamoDB cache for our shenanigans."""
+
+    TTL_ATTRIBUTE_NAME = "time_to_live"
+
+    def __init__(
+        self, prefix: str, hash_keys: bool = True, default_ttl: int = DEFAULT_TTL_SECONDS, table_name: str | None = None
+    ):
+        super().__init__(prefix, hash_keys, default_ttl)
+        self.client = boto3.resource("dynamodb")
+        if table_name is None:
+            raise ValueError("No table_name was provided for DynamoDBCache.")
+        self.table_name = table_name
+        self.table = self.client.Table(table_name)
+
+    def _get(self, key: str) -> str | None:
+        if (cached := self._get_bytes(key)) is None:
+            return None
+        return cached.decode("utf-8")
+
+    def _set(self, key: str, value: str) -> None:
+        return self._set_bytes(key, value.encode("utf-8"))
+
+    def _set_bytes(self, key: str, value: bytes) -> None:
+        expiration_time = int(time.time()) + self.default_ttl
+        cache_key = self._key(key)
+        compressed_value = self._compress_bytes(value)
+        if len(compressed_value) > DYNAMODB_MAX_LENGTH:
+            logger.warning(
+                "Value is too long to store in DynamoDB.",
+                original_key=cache_key,
+                cache_key=cache_key,
+                length=len(compressed_value),
+            )
+            raise CachingError(f"Value is too long to store in DynamoDB: {len(compressed_value)}")
+        self.table.put_item(
+            Item={"key": cache_key, "value": compressed_value, self.TTL_ATTRIBUTE_NAME: expiration_time}
+        )
+
+    def _get_bytes(self, key: str) -> bytes | None:
+        cache_key = self._key(key)
+        response = self.table.get_item(Key={"key": cache_key})
+        item = response.get("Item")
+        if item:
+            return self._decompress_bytes(bytes(cast(Any, item["value"])))
+        return None
+
+    def _delete(self, key: str) -> None:
+        key = self._key(key)
+        self.table.delete_item(Key={"key": key})
+
+    def _clear(self) -> None:
+        """
+        Deletes all items in the table.
+
+        Warning: DynamoDB doesn't have a built-in clear mechanism, so we scan and delete all items manually.
+        """
+        logger.info("Clearing cache.", cache_table=self.table_name)
+        scan = self.table.scan()
+        with self.table.batch_writer() as batch:
+            for item in scan["Items"]:
+                batch.delete_item(Key={"key": item["key"]})
+
+    def _hit(self, key: str) -> bool:
+        cache_key = self._key(key)
+        item = self.table.get_item(Key={"key": cache_key}, ProjectionExpression=self.TTL_ATTRIBUTE_NAME).get("Item")
+        if not item:
+            return False
+        item_ttl = int(cast(Any, item.get(self.TTL_ATTRIBUTE_NAME) or 0))
+        return bool(item and item_ttl > int(time.time()))

--- a/hyperion/adapters/cache/filesystem.py
+++ b/hyperion/adapters/cache/filesystem.py
@@ -1,0 +1,180 @@
+"""Filesystem-backed :class:`Cache` adapter (lite -- stdlib only).
+
+``snappy`` compression is delegated to the abstract base; it degrades
+gracefully when ``python-snappy`` is not installed.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import IO, Literal, overload
+
+from hyperion.log import get_logger
+from hyperion.ports.cache import DEFAULT_TTL_SECONDS, Cache, CacheKeyOpenMode
+
+DEFAULT_LOCAL_FILE_CACHE_MAX_SIZE = 256 * (1024**2)
+
+logger = get_logger("cache")
+
+
+class LocalFileCache(Cache):
+    """A local file cache for our shenanigans."""
+
+    def __init__(
+        self,
+        prefix: str,
+        hash_keys: bool = True,
+        default_ttl: int = DEFAULT_TTL_SECONDS,
+        root_path: Path | None = None,
+        max_size: int | None = DEFAULT_LOCAL_FILE_CACHE_MAX_SIZE,
+        use_compression: bool = True,
+    ) -> None:
+        super().__init__(prefix, hash_keys, default_ttl)
+        self.root_path = root_path or Path(tempfile.mkdtemp())
+        if self.root_path.exists() and not self.root_path.is_dir():
+            raise ValueError(f"Given local cache path ({self.root_path.as_posix()}) is not a directory.")
+        self.use_compression = use_compression
+        self.max_size = max_size
+        self._assert_root_path()
+        logger.info(f"Initialized LocalFileCache in {self.root_path.as_posix()}.", root_path=self.root_path.as_posix())
+        if not hash_keys:
+            logger.warning("When using filesystem cache, it is recommended to hash keys.")
+        self.shrink_to_fit_max_size()
+
+    def _assert_root_path(self) -> None:
+        self.root_path.mkdir(parents=True, exist_ok=True)
+
+    def _cleanup(self) -> None:
+        """Clean up all expired files from the cache."""
+        self._assert_root_path()
+        for key_path in self.root_path.iterdir():
+            if key_path.is_file() and self._is_expired(key_path):
+                logger.debug("Cleaning up expired file.", key_path=key_path)
+                key_path.unlink()
+
+    def get_total_size(self) -> int:
+        self._assert_root_path()
+        return sum(key_path.stat().st_size for key_path in self.root_path.iterdir() if key_path.is_file())
+
+    @overload
+    @contextmanager
+    def _open(self, key: str, mode: Literal["str"]) -> Iterator[IO[str]]:
+        pass
+
+    @overload
+    @contextmanager
+    def _open(self, key: str, mode: Literal["bytes"]) -> Iterator[IO[bytes]]:
+        pass
+
+    @contextmanager
+    def _open(self, key: str, mode: CacheKeyOpenMode = "str") -> Iterator[IO[str] | IO[bytes]]:
+        self.hit(key)  # this should expire the file if needed
+        if self.use_compression:
+            logger.warning(
+                "Current LocalFileCache implementation does not work well with compression on. "
+                "It compresses the content in-memory. For now, you should consider using "
+                "use_compression=False and utilizing e.g. snappy or gzip manually."
+            )
+            with super()._open(key, mode) as file:
+                yield file
+            return
+        key_path = self._key_path(key)
+        key_path.touch(exist_ok=True)
+        if mode == "str":
+            with key_path.open("a+") as file:
+                file.seek(0)
+                yield file
+        elif mode == "bytes":
+            with key_path.open("a+b") as file:
+                file.seek(0)
+                yield file
+        else:
+            raise ValueError(f"Unsupported open mode {mode!r} - 'str' or 'bytes' are supported.")
+        if not key_path.stat().st_size:
+            key_path.unlink(missing_ok=True)
+
+    def shrink_to_fit_max_size(self) -> None:
+        self._cleanup()
+        if not self.max_size or self.max_size < 0:
+            return
+        total_size = self.get_total_size()
+        keys_ordered = sorted(self.root_path.iterdir(), key=lambda key: key.stat().st_mtime)
+        while total_size > self.max_size:
+            key_path = keys_ordered.pop(0)
+            if not key_path.is_file():
+                continue
+            size = key_path.stat().st_size
+            logger.debug("Cleaning up old file to make some space.", key_path=key_path, size=size)
+            key_path.unlink()
+            total_size -= size
+
+    def _key_path(self, key: str) -> Path:
+        return self.root_path / self._key(key)
+
+    def _is_expired(self, key: str | Path) -> bool:
+        self._assert_root_path()
+        if isinstance(key, str):
+            key = self._key_path(key)
+        current_time = time.time()
+        return (current_time - key.stat().st_mtime) > self.default_ttl
+
+    def _get(self, key: str) -> str | None:
+        if (cached := self._get_bytes(key)) is None:
+            return None
+        return cached.decode("utf-8")
+
+    def _get_bytes(self, key: str) -> bytes | None:
+        self._assert_root_path()
+        if not self.hit(key):
+            return None
+        key_path = self._key_path(key)
+        logger.debug("Reading key from file.", key=key, path=key_path.as_posix())
+        content = key_path.read_bytes()
+        if self.use_compression:
+            return self._decompress_bytes(content)
+        return content
+
+    def _perform_set(self, key: str, value: str | bytes) -> None:
+        self._assert_root_path()
+        key_path = self._key_path(key)
+        logger.debug("Storing key into a file.", key=key, path=key_path.as_posix())
+        if isinstance(value, str):
+            value = value.encode("utf-8")
+        content = self._compress_bytes(value) if self.use_compression else value
+        key_path.write_bytes(content)
+
+    def _set(self, key: str, value: str) -> None:
+        return self._perform_set(key, value)
+
+    def _set_bytes(self, key: str, value: bytes) -> None:
+        return self._perform_set(key, value)
+
+    def _delete(self, key: str) -> None:
+        self._assert_root_path()
+        key_path = self._key_path(key)
+        if not key_path.exists():
+            return None
+        logger.debug("Removing cached key.", key=key, path=key_path.as_posix())
+        key_path.unlink()
+
+    def _hit(self, key: str) -> bool:
+        key_path = self._key_path(key)
+        if not key_path.exists():
+            return False
+        if self._is_expired(key_path):
+            logger.debug("Key is expired, deleting file.", key=key, key_path=key_path)
+            key_path.unlink()
+            return False
+        return True
+
+    def _clear(self) -> None:
+        self._assert_root_path()
+        for file in self.root_path.iterdir():
+            if not file.is_file():
+                continue
+            logger.debug("Removing cached key.", path=file.as_posix())
+            file.unlink()

--- a/hyperion/adapters/cache/memory.py
+++ b/hyperion/adapters/cache/memory.py
@@ -1,0 +1,49 @@
+"""In-memory :class:`Cache` adapter (lite -- cachetools-backed)."""
+
+from __future__ import annotations
+
+from base64 import b64decode, b64encode
+
+import cachetools
+
+from hyperion.ports.cache import DEFAULT_TTL_SECONDS, Cache, CachingError
+
+
+class InMemoryCache(Cache):
+    """An in-memory cache for our shenanigans."""
+
+    MAX_KEYS = 1000
+    cache: cachetools.TTLCache[str, str]
+
+    def __init__(
+        self, prefix: str, hash_keys: bool = True, default_ttl: int = DEFAULT_TTL_SECONDS, max_size: int = MAX_KEYS
+    ):
+        super().__init__(prefix, hash_keys, default_ttl)
+        self.max_size = max_size
+        self.cache = cachetools.TTLCache[str, str](maxsize=self.max_size, ttl=self.default_ttl)
+
+    def _get(self, key: str) -> str | None:
+        return self.cache.get(self._key(key))
+
+    def _set(self, key: str, value: str) -> None:
+        self.cache[self._key(key)] = value
+
+    def _set_bytes(self, key: str, value: bytes) -> None:
+        self.cache[self._key(key)] = b64encode(value).decode("ascii")
+
+    def _get_bytes(self, key: str) -> bytes | None:
+        if (cached := self.cache.get(self._key(key))) is None:
+            return None
+        try:
+            return b64decode(cached.encode("ascii"))
+        except Exception as error:
+            raise CachingError(f"Failed to decode cached key {key!r}, make sure it was stored as bytes.") from error
+
+    def _delete(self, key: str) -> None:
+        self.cache.pop(self._key(key), None)
+
+    def _clear(self) -> None:
+        self.cache.clear()
+
+    def _hit(self, key: str) -> bool:
+        return self._key(key) in self.cache

--- a/hyperion/adapters/http/__init__.py
+++ b/hyperion/adapters/http/__init__.py
@@ -1,0 +1,4 @@
+"""HTTP adapters. Import the concrete module you need explicitly.
+
+``proxy`` is lite (httpx only). No eager re-exports here.
+"""

--- a/hyperion/adapters/http/proxy.py
+++ b/hyperion/adapters/http/proxy.py
@@ -1,0 +1,45 @@
+"""HTTP proxy helpers (lite -- httpx only)."""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+import httpx
+
+from hyperion.config import http_config
+from hyperion.log import get_logger
+
+logger = get_logger("hyperion-http")
+
+
+def redact_url(url: str, replace: str = "***") -> str:
+    """Replace password from {url} (if any) with {replace}.
+    If the url contains no password, url is returned unchanged.
+    """
+    parsed = urlparse(url)
+    if parsed.password:
+        return parsed._replace(netloc=f"{parsed.username}:{replace}@{parsed.hostname}").geturl()
+    return url
+
+
+def get_proxy_mounts() -> dict[str, httpx.AsyncHTTPTransport]:
+    """Build httpx proxy mounts from HYPERION_HTTP_PROXY_HTTP / HYPERION_HTTP_PROXY_HTTPS env vars.
+
+    If only one of the two is set, it is used for both http:// and https://.
+    """
+    proxy_mounts: dict[str, httpx.AsyncHTTPTransport] = {}
+    if http_config.proxy_http:
+        redacted_url = redact_url(http_config.proxy_http)
+        logger.info("Configuring HTTP proxy for http://", proxy_url=redacted_url)
+        proxy_mounts["http://"] = httpx.AsyncHTTPTransport(proxy=http_config.proxy_http)
+        if not http_config.proxy_https:
+            logger.info("Configuring HTTP proxy for https://", proxy_url=redacted_url)
+            proxy_mounts["https://"] = httpx.AsyncHTTPTransport(proxy=http_config.proxy_http)
+    if http_config.proxy_https:
+        redacted_url = redact_url(http_config.proxy_https)
+        logger.info("Configuring HTTP proxy for https://", proxy_url=redacted_url)
+        proxy_mounts["https://"] = httpx.AsyncHTTPTransport(proxy=http_config.proxy_https)
+        if not http_config.proxy_http:
+            logger.info("Configuring HTTP proxy for http://", proxy_url=redacted_url)
+            proxy_mounts["http://"] = httpx.AsyncHTTPTransport(proxy=http_config.proxy_https)
+    return proxy_mounts

--- a/hyperion/adapters/keyval/__init__.py
+++ b/hyperion/adapters/keyval/__init__.py
@@ -1,0 +1,5 @@
+"""Key-value store adapters. Import the concrete module you need explicitly.
+
+``memory`` and ``filesystem`` are lite; ``dynamodb`` requires boto3 (``[aws]``).
+No eager re-exports here -- touching this namespace must stay boto3-free.
+"""

--- a/hyperion/adapters/keyval/dynamodb.py
+++ b/hyperion/adapters/keyval/dynamodb.py
@@ -1,0 +1,69 @@
+"""DynamoDB-backed :class:`KeyValueStore` adapter (requires boto3 -- ``[aws]``).
+
+The table must have a key attribute and a value attribute.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any, cast
+
+import boto3
+
+from hyperion.ports.keyval import CompressionType, KeyValueStore
+
+if TYPE_CHECKING:
+    from mypy_boto3_dynamodb.type_defs import ScanInputTableScanTypeDef
+
+
+class DynamoDBStore(KeyValueStore):
+    """A key-value store using DynamoDB.
+
+    The table must have a key attribute and a value attribute.
+    """
+
+    def __init__(
+        self,
+        prefix: str | None = None,
+        compression: CompressionType | None = None,
+        table_name: str | None = None,
+        key_attribute: str = "key",
+        value_attribute: str = "value",
+    ):
+        super().__init__(prefix, compression)
+        self.client = boto3.resource("dynamodb")
+        if table_name is None:
+            raise ValueError("No table name provided for DynamoDBStore.")
+        self.table_name = table_name
+        self.table = self.client.Table(self.table_name)
+        self.key_attribute = key_attribute
+        self.value_attribute = value_attribute
+
+    def _get_raw(self, hashed_key: str) -> bytes | None:
+        response = self.table.get_item(Key={self.key_attribute: hashed_key})
+        item = response.get("Item")
+        if not item:
+            return None
+        return bytes(cast(Any, item[self.value_attribute]))
+
+    def _set_raw(self, hashed_key: str, compresed_value: bytes) -> None:
+        self.table.put_item(Item={self.key_attribute: hashed_key, self.value_attribute: compresed_value})
+
+    def _delete_raw(self, hashed_key: str) -> None:
+        self.table.delete_item(Key={self.key_attribute: hashed_key})
+
+    def _iter_all_keys(self) -> Iterable[str]:
+        scan_kwargs: ScanInputTableScanTypeDef = {
+            "ProjectionExpression": "#k",
+            "ExpressionAttributeNames": {"#k": self.key_attribute},
+        }
+        while True:
+            response = self.table.scan(**scan_kwargs)
+            for item in response.get("Items", []):
+                key = str(item[self.key_attribute])
+                if self.prefix:
+                    key = key.replace(f"{self.prefix}:", "", 1)
+                yield key
+            if "LastEvaluatedKey" not in response:
+                break
+            scan_kwargs["ExclusiveStartKey"] = response["LastEvaluatedKey"]

--- a/hyperion/adapters/keyval/filesystem.py
+++ b/hyperion/adapters/keyval/filesystem.py
@@ -1,0 +1,74 @@
+"""Filesystem-backed :class:`KeyValueStore` adapter (lite -- stdlib only).
+
+One file per (hashed, prefixed) key under a root directory, mirroring the
+``LocalFileCache`` idiom. Keys are url-safe-base64 encoded into filenames so
+arbitrary keys (containing ``/``, ``:`` ...) are safe and reversible. Writes
+are atomic (write to a temp file in the same directory, then ``os.replace``).
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import tempfile
+from collections.abc import Iterable
+from pathlib import Path
+
+from hyperion.log import get_logger
+from hyperion.ports.keyval import CompressionType, KeyValueStore
+
+logger = get_logger("adapters.keyval.filesystem")
+
+
+class FilesystemStore(KeyValueStore):
+    """A persistent key-value store backed by a directory of files."""
+
+    def __init__(
+        self,
+        root_path: Path | str,
+        prefix: str | None = None,
+        compression: CompressionType | None = None,
+    ) -> None:
+        super().__init__(prefix, compression)
+        self.root_path = Path(root_path)
+        if self.root_path.exists() and not self.root_path.is_dir():
+            raise ValueError(f"Given key-value store path ({self.root_path.as_posix()}) is not a directory.")
+        self.root_path.mkdir(parents=True, exist_ok=True)
+        logger.info("Initialized FilesystemStore.", root_path=self.root_path.as_posix())
+
+    @staticmethod
+    def _encode(hashed_key: str) -> str:
+        return base64.urlsafe_b64encode(hashed_key.encode("utf-8")).decode("ascii")
+
+    @staticmethod
+    def _decode(filename: str) -> str:
+        return base64.urlsafe_b64decode(filename.encode("ascii")).decode("utf-8")
+
+    def _path(self, hashed_key: str) -> Path:
+        return self.root_path / self._encode(hashed_key)
+
+    def _get_raw(self, hashed_key: str) -> bytes | None:
+        key_path = self._path(hashed_key)
+        if not key_path.exists():
+            return None
+        return key_path.read_bytes()
+
+    def _set_raw(self, hashed_key: str, compresed_value: bytes) -> None:
+        key_path = self._path(hashed_key)
+        with tempfile.NamedTemporaryFile("wb", dir=self.root_path, delete=False) as tmp_file:
+            tmp_file.write(compresed_value)
+            tmp_path = tmp_file.name
+        os.replace(tmp_path, key_path)  # noqa: PTH105 - atomic same-dir replace
+
+    def _delete_raw(self, hashed_key: str) -> None:
+        self._path(hashed_key).unlink(missing_ok=True)
+
+    def _iter_all_keys(self) -> Iterable[str]:
+        with os.scandir(self.root_path) as entries:
+            for entry in entries:
+                if not entry.is_file():
+                    continue
+                key = self._decode(entry.name)
+                if self.prefix:
+                    key = key.replace(f"{self.prefix}:", "", 1)
+                yield key

--- a/hyperion/adapters/keyval/memory.py
+++ b/hyperion/adapters/keyval/memory.py
@@ -1,0 +1,30 @@
+"""In-memory :class:`KeyValueStore` adapter (lite -- not persistent)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from hyperion.ports.keyval import CompressionType, KeyValueStore
+
+
+class InMemoryStore(KeyValueStore):
+    """An in-memory key-value store.
+
+    This store is not persistent and is not shared between instances.
+    """
+
+    def __init__(self, prefix: str | None = None, compression: CompressionType | None = None):
+        super().__init__(prefix, compression)
+        self.store: dict[str, bytes] = {}
+
+    def _get_raw(self, hashed_key: str) -> bytes | None:
+        return self.store.get(hashed_key)
+
+    def _set_raw(self, hashed_key: str, compresed_value: bytes) -> None:
+        self.store[hashed_key] = compresed_value
+
+    def _delete_raw(self, hashed_key: str) -> None:
+        self.store.pop(hashed_key, None)
+
+    def _iter_all_keys(self) -> Iterable[str]:
+        yield from self.store

--- a/hyperion/adapters/queue/__init__.py
+++ b/hyperion/adapters/queue/__init__.py
@@ -1,0 +1,5 @@
+"""Message queue adapters. Import the concrete module you need explicitly.
+
+``memory`` and ``filesystem`` are lite; ``sqs`` requires boto3 (``[aws]``).
+No eager re-exports here -- touching this namespace must stay boto3-free.
+"""

--- a/hyperion/adapters/queue/filesystem.py
+++ b/hyperion/adapters/queue/filesystem.py
@@ -1,0 +1,97 @@
+"""File-backed :class:`Queue` adapter (lite -- stdlib only)."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from hyperion.domain.messages import Message, SerializedMessage
+from hyperion.log import get_logger
+from hyperion.ports.queue import Queue
+
+if sys.version_info >= (3, 11) and TYPE_CHECKING:
+    from typing import Self
+
+if sys.version_info < (3, 11) and TYPE_CHECKING:
+    from typing_extensions import Self
+
+logger = get_logger("hyperion-queue")
+
+
+class FileQueue(Queue):
+    def __init__(self, queue_path: Path, *, overwrite: bool = False, exclusive: bool = False) -> None:
+        """File-based message queue.
+
+        If the queue is exclusive and it is entered multiple times, a RuntimeError will be raised.
+
+        Args:
+            queue_path (Path): The path to the queue file.
+            overwrite (bool, optional): Whether to overwrite the queue file if it exists. Defaults to False.
+            exclusive (bool, optional): Whether to use exclusive access to the queue file. Defaults to False.
+        """
+        self._messages: list[Message] = []
+        self._context_stacklevel = 0
+        self._exclusive = exclusive
+        self.queue_path = queue_path.resolve()
+        super().__init__()
+        if queue_path.exists():
+            if not queue_path.resolve().is_file():
+                raise FileExistsError(f"Queue path {queue_path} already exists and is not a file.")
+            if not overwrite:
+                raise FileExistsError(f"Queue path {queue_path} already exists, set overwrite=True to ignore this.")
+            logger.warning("Queue path already exists, it will be overwritten.", queue_path=queue_path, queue=self)
+
+    def send(self, message: Message) -> None:
+        if self._context_stacklevel == 0:
+            logger.warning("Using FileQueue outside of a context manager does not persist the messages.", queue=self)
+        self._messages.append(message)
+
+    def delete(self, receipt_handle: str) -> None:
+        raise NotImplementedError("FileQueue does not implement message deletion.")
+
+    def _flush(self) -> None:
+        serializable_list = [
+            {"message_type": message.__class__.__name__, "message": message.model_dump_json()}
+            for message in self._messages
+        ]
+        with tempfile.NamedTemporaryFile("w", delete=False) as tmp_file:
+            json.dump(serializable_list, tmp_file)
+        shutil.move(tmp_file.name, self.queue_path)
+        logger.info(
+            f"Flushed {len(self._messages)} from FileQueue.",
+            queue=self,
+            messages=len(self._messages),
+            queue_path=self.queue_path,
+        )
+        self._messages.clear()
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} at {hex(id(self))} exclusive={self._exclusive} path={self.queue_path}>"
+
+    def __enter__(self) -> Self:
+        if self._exclusive and self._context_stacklevel != 0:
+            raise RuntimeError(
+                "FileQueue's context has already been entered, this cannot be done twice in exclusive mode."
+            )
+        self._context_stacklevel += 1
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        self._context_stacklevel -= 1
+        if self._context_stacklevel != 0:
+            logger.info("FileQueue's context was exited, but there is still an open context somewhere, skipping flush.")
+            return
+        self._flush()
+
+    @staticmethod
+    def iter_messages_from_file(queue_file: Path) -> Iterator[Message]:
+        with queue_file.open("r", encoding="utf-8") as file:
+            raw_messages = json.load(file)
+        for raw_message in raw_messages:
+            serialized_message = SerializedMessage.model_validate(raw_message)
+            yield Message.deserialize(serialized_message.message, serialized_message.message_type)

--- a/hyperion/adapters/queue/memory.py
+++ b/hyperion/adapters/queue/memory.py
@@ -1,0 +1,22 @@
+"""In-memory :class:`Queue` adapter (lite -- not persistent)."""
+
+from __future__ import annotations
+
+from hyperion.domain.messages import Message
+from hyperion.ports.queue import Queue
+
+
+class InMemoryQueue(Queue):
+    def __init__(self) -> None:
+        super().__init__()
+        self._messages: list[Message] = []
+
+    def send(self, message: Message) -> None:
+        self._messages.append(message)
+
+    def delete(self, receipt_handle: str) -> None:
+        """Delete the message using the created as isoformat."""
+        for message in self._messages:
+            if message.created.isoformat() == receipt_handle:
+                self._messages.remove(message)
+                break

--- a/hyperion/adapters/queue/sqs.py
+++ b/hyperion/adapters/queue/sqs.py
@@ -1,0 +1,33 @@
+"""SQS-backed :class:`Queue` adapter (requires boto3 -- ``[aws]``)."""
+
+from __future__ import annotations
+
+from boto3 import client
+
+from hyperion.domain.messages import Message
+from hyperion.ports.queue import Queue
+
+
+class SQSQueue(Queue):
+    def __init__(self, queue_url: str) -> None:
+        super().__init__()
+        self._queue_url = queue_url
+        self._client = client("sqs")
+
+    def send(self, message: Message) -> None:
+        self._client.send_message(
+            QueueUrl=self._queue_url,
+            MessageBody=message.model_dump_json(),
+            MessageAttributes={
+                "MessageType": {
+                    "DataType": "String",
+                    "StringValue": message.__class__.__name__,
+                }
+            },
+        )
+
+    def delete(self, receipt_handle: str) -> None:
+        self._client.delete_message(QueueUrl=self._queue_url, ReceiptHandle=receipt_handle)
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} {self._queue_url}>"

--- a/hyperion/adapters/schema_registry/__init__.py
+++ b/hyperion/adapters/schema_registry/__init__.py
@@ -1,0 +1,5 @@
+"""Schema registry adapters. Import the concrete module you need explicitly.
+
+``local`` is lite; ``s3`` requires boto3 (``[aws]``).
+No eager re-exports here -- touching this namespace must stay boto3-free.
+"""

--- a/hyperion/adapters/schema_registry/local.py
+++ b/hyperion/adapters/schema_registry/local.py
@@ -1,0 +1,53 @@
+"""Local-filesystem :class:`SchemaStore` adapter (lite -- stdlib only)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from hyperion.domain.assets import AssetType
+from hyperion.log import get_logger
+from hyperion.ports.schema_registry import SchemaStore
+
+logger = get_logger("schema-store")
+
+# Canonical location of the packaged avro schemas: ``hyperion/catalog/avro_schemas``.
+# ``parents[2]`` of ``hyperion/adapters/schema_registry/local.py`` is the ``hyperion``
+# package root. Preserved verbatim from the pre-S6 ``hyperion.catalog.schema`` default.
+AVRO_SCHEMAS_PATH = Path(__file__).resolve().parents[2] / "catalog" / "avro_schemas"
+
+
+class LocalSchemaStore(SchemaStore):
+    """Schema store for local files."""
+
+    def __init__(self, schemas_path: Path = AVRO_SCHEMAS_PATH) -> None:
+        """Initialize the local schema store with the given path.
+
+        Args:
+            schemas_path (Path, optional): The path to the schemas. Defaults to AVRO_SCHEMAS_PATH.
+        """
+        super().__init__(schemas_path.as_posix())
+        self.schemas_path = schemas_path
+        if not schemas_path.exists():
+            logger.critical("Provided schemas path does not exist.", schemas_path=schemas_path.as_posix())
+            raise FileNotFoundError("Provided schemas path does not exist.")
+
+    def get_schema_from_path(self, schema_path: str) -> dict[str, Any]:
+        path = Path(schema_path)
+        logger.info("Reading avro schema from stored json file.", path=path.as_posix())
+        with path.open("r", encoding="utf-8") as file:
+            schema = json.load(file)
+        if not isinstance(schema, dict):
+            raise TypeError(f"Schema has unexpected type {type(schema)}, expected 'dict'.")
+        return schema
+
+    def get_schema(self, asset_name: str, schema_version: int, asset_type: AssetType) -> dict[str, Any]:
+        path = self.schemas_path / asset_type / f"{asset_name}.v{schema_version}.avro.json"
+        logger.info(
+            "Reading avro schema from stored json file.",
+            path=path.as_posix(),
+            asset_name=asset_name,
+            asset_type=asset_type,
+        )
+        return self.get_schema_from_path(path.as_posix())

--- a/hyperion/adapters/schema_registry/s3.py
+++ b/hyperion/adapters/schema_registry/s3.py
@@ -1,0 +1,47 @@
+"""S3-backed :class:`SchemaStore` adapter (requires boto3 -- ``[aws]``)."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from typing import Any, cast
+
+from hyperion.domain.assets import AssetType
+from hyperion.infrastructure.aws import S3Client
+from hyperion.log import get_logger
+from hyperion.ports.schema_registry import SchemaStore
+
+logger = get_logger("schema-store")
+
+
+@lru_cache(maxsize=256)
+def _get_schema_from_s3(bucket: str, key: str, client: S3Client) -> dict[str, Any]:
+    return cast(dict[str, Any], json.loads(client.download_as_string(bucket, key)))
+
+
+class S3SchemaStore(SchemaStore):
+    """Schema store for S3."""
+
+    def __init__(self, bucket: str, prefix: str) -> None:
+        """Initialize the S3 schema store with the given bucket and prefix.
+
+        Args:
+            bucket (str): The S3 bucket.
+            prefix (str): The prefix in the bucket.
+        """
+        super().__init__(f"s3://{bucket}/{prefix}")
+        self.bucket = bucket
+        self.prefix = prefix
+        self.s3_client = S3Client()
+
+    def get_schema_from_path(self, schema_path: str) -> dict[str, Any]:
+        logger.info("Getting avro schema from S3.", bucket=self.bucket, key=schema_path)
+        try:
+            return _get_schema_from_s3(self.bucket, schema_path, self.s3_client)
+        except Exception:
+            logger.critical("Failed to get avro schema from S3.", bucket=self.bucket, key=schema_path)
+            raise
+
+    def get_schema(self, asset_name: str, schema_version: int, asset_type: AssetType) -> dict[str, Any]:
+        key = f"{asset_type}/{asset_name}.v{schema_version}.avro.json"
+        return self.get_schema_from_path(key)

--- a/hyperion/adapters/secrets/__init__.py
+++ b/hyperion/adapters/secrets/__init__.py
@@ -1,0 +1,5 @@
+"""Secrets manager adapters. Import the concrete module you need explicitly.
+
+``env`` and ``dummy`` are lite; ``aws_sm`` requires boto3 (``[aws]``).
+No eager re-exports here -- touching this namespace must stay boto3-free.
+"""

--- a/hyperion/adapters/secrets/aws_sm.py
+++ b/hyperion/adapters/secrets/aws_sm.py
@@ -1,0 +1,17 @@
+"""AWS Secrets Manager :class:`SecretsManager` adapter (requires boto3 -- ``[aws]``)."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import boto3
+
+from hyperion.ports.secrets import SecretsManager
+
+
+class AWSSecretsManager(SecretsManager):
+    def __init__(self) -> None:
+        self.client = boto3.client("secretsmanager")
+
+    def get_secret(self, secret_name: str) -> str:
+        return cast(str, self.client.get_secret_value(SecretId=secret_name)["SecretString"])

--- a/hyperion/adapters/secrets/dummy.py
+++ b/hyperion/adapters/secrets/dummy.py
@@ -1,0 +1,14 @@
+"""No-op :class:`SecretsManager` adapter (lite -- returns empty strings)."""
+
+from __future__ import annotations
+
+from hyperion.log import get_logger
+from hyperion.ports.secrets import SecretsManager
+
+logger = get_logger("hyperion-secrets")
+
+
+class DummySecretsManager(SecretsManager):
+    def get_secret(self, secret_name: str) -> str:
+        logger.warning("Using dummy secrets manager, no values will be returned.", secret_name=secret_name)
+        return ""

--- a/hyperion/adapters/secrets/env.py
+++ b/hyperion/adapters/secrets/env.py
@@ -1,0 +1,24 @@
+"""Environment-variable :class:`SecretsManager` adapter (lite -- ``os.environ``)."""
+
+from __future__ import annotations
+
+import os
+
+from hyperion.log import get_logger
+from hyperion.ports.secrets import SecretsManager
+
+logger = get_logger("hyperion-secrets")
+
+
+class EnvSecretsManager(SecretsManager):
+    """Resolve secrets from process environment variables.
+
+    The secret name is looked up verbatim as an environment variable.
+    """
+
+    def get_secret(self, secret_name: str) -> str:
+        try:
+            return os.environ[secret_name]
+        except KeyError:
+            logger.error("Secret not found in environment.", secret_name=secret_name)
+            raise

--- a/hyperion/catalog/catalog.py
+++ b/hyperion/catalog/catalog.py
@@ -30,7 +30,7 @@ from hyperion.domain.assets import (
     FeatureAsset,
     PersistentStoreAsset,
 )
-from hyperion.infrastructure.message_queue import ArrivalEvent, DataLakeArrivalMessage
+from hyperion.domain.messages import ArrivalEvent, DataLakeArrivalMessage
 from hyperion.log import get_logger
 from hyperion.ports.queue import Queue
 from hyperion.ports.schema_registry import SchemaStore

--- a/hyperion/catalog/schema.py
+++ b/hyperion/catalog/schema.py
@@ -1,32 +1,37 @@
-"""Concrete schema store adapters.
+"""Deprecated import shim for schema store adapters.
 
 .. deprecated::
     The abstract :class:`SchemaStore` moved to
-    :mod:`hyperion.ports.schema_registry`. Import it from there. This module
-    keeps it importable (with a :class:`DeprecationWarning`) for the whole
-    ``hyperion-sdk`` 1.x line and still hosts the concrete adapters until S6.
+    :mod:`hyperion.ports.schema_registry`. The concrete adapters moved to
+    ``hyperion.adapters.schema_registry.*`` (``LocalSchemaStore`` /
+    :data:`AVRO_SCHEMAS_PATH` -> :mod:`hyperion.adapters.schema_registry.local`,
+    ``S3SchemaStore`` -> :mod:`hyperion.adapters.schema_registry.s3`). Import
+    them from there. This module keeps every symbol importable (with a
+    :class:`DeprecationWarning`, resolved lazily so the import does not pull
+    boto3) for the whole ``hyperion-sdk`` 1.x line. The symbols are removed in 2.0.
 """
 
-import json
-from functools import lru_cache
-from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+import importlib
+from typing import TYPE_CHECKING
 
 from hyperion._compat import moved_attr
-from hyperion.domain.assets import AssetType
-from hyperion.infrastructure.aws import S3Client
-from hyperion.log import get_logger
 from hyperion.ports.schema_registry import SchemaStore as _SchemaStore
 
 if TYPE_CHECKING:
+    from hyperion.adapters.schema_registry.local import AVRO_SCHEMAS_PATH, LocalSchemaStore
+    from hyperion.adapters.schema_registry.s3 import S3SchemaStore
     from hyperion.ports.schema_registry import SchemaStore
 
-logger = get_logger("schema-store")
-
-AVRO_SCHEMAS_PATH = Path(__file__).parent / "avro_schemas"
+_OLD_MODULE = "hyperion.catalog.schema"
 
 _MOVED: dict[str, tuple[object, str]] = {
     "SchemaStore": (_SchemaStore, "hyperion.ports.schema_registry"),
+}
+
+_MOVED_LAZY: dict[str, str] = {
+    "AVRO_SCHEMAS_PATH": "hyperion.adapters.schema_registry.local",
+    "LocalSchemaStore": "hyperion.adapters.schema_registry.local",
+    "S3SchemaStore": "hyperion.adapters.schema_registry.s3",
 }
 
 __all__ = [
@@ -40,75 +45,9 @@ __all__ = [
 def __getattr__(name: str) -> object:
     if name in _MOVED:
         value, new_module = _MOVED[name]
-        return moved_attr(
-            name=name, value=value, old_module="hyperion.catalog.schema", new_module=new_module
-        )
+        return moved_attr(name=name, value=value, old_module=_OLD_MODULE, new_module=new_module)
+    if name in _MOVED_LAZY:
+        new_module = _MOVED_LAZY[name]
+        module = importlib.import_module(new_module)
+        return moved_attr(name=name, value=getattr(module, name), old_module=_OLD_MODULE, new_module=new_module)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-class LocalSchemaStore(_SchemaStore):
-    """Schema store for local files."""
-
-    def __init__(self, schemas_path: Path = AVRO_SCHEMAS_PATH) -> None:
-        """Initialize the local schema store with the given path.
-
-        Args:
-            schemas_path (Path, optional): The path to the schemas. Defaults to AVRO_SCHEMAS_PATH.
-        """
-        super().__init__(schemas_path.as_posix())
-        self.schemas_path = schemas_path
-        if not schemas_path.exists():
-            logger.critical("Provided schemas path does not exist.", schemas_path=schemas_path.as_posix())
-            raise FileNotFoundError("Provided schemas path does not exist.")
-
-    def get_schema_from_path(self, schema_path: str) -> dict[str, Any]:
-        path = Path(schema_path)
-        logger.info("Reading avro schema from stored json file.", path=path.as_posix())
-        with path.open("r", encoding="utf-8") as file:
-            schema = json.load(file)
-        if not isinstance(schema, dict):
-            raise TypeError(f"Schema has unexpected type {type(schema)}, expected 'dict'.")
-        return schema
-
-    def get_schema(self, asset_name: str, schema_version: int, asset_type: AssetType) -> dict[str, Any]:
-        path = self.schemas_path / asset_type / f"{asset_name}.v{schema_version}.avro.json"
-        logger.info(
-            "Reading avro schema from stored json file.",
-            path=path.as_posix(),
-            asset_name=asset_name,
-            asset_type=asset_type,
-        )
-        return self.get_schema_from_path(path.as_posix())
-
-
-@lru_cache(maxsize=256)
-def _get_schema_from_s3(bucket: str, key: str, client: S3Client) -> dict[str, Any]:
-    return cast(dict[str, Any], json.loads(client.download_as_string(bucket, key)))
-
-
-class S3SchemaStore(_SchemaStore):
-    """Schema store for S3."""
-
-    def __init__(self, bucket: str, prefix: str) -> None:
-        """Initialize the S3 schema store with the given bucket and prefix.
-
-        Args:
-            bucket (str): The S3 bucket.
-            prefix (str): The prefix in the bucket.
-        """
-        super().__init__(f"s3://{bucket}/{prefix}")
-        self.bucket = bucket
-        self.prefix = prefix
-        self.s3_client = S3Client()
-
-    def get_schema_from_path(self, schema_path: str) -> dict[str, Any]:
-        logger.info("Getting avro schema from S3.", bucket=self.bucket, key=schema_path)
-        try:
-            return _get_schema_from_s3(self.bucket, schema_path, self.s3_client)
-        except Exception:
-            logger.critical("Failed to get avro schema from S3.", bucket=self.bucket, key=schema_path)
-            raise
-
-    def get_schema(self, asset_name: str, schema_version: int, asset_type: AssetType) -> dict[str, Any]:
-        key = f"{asset_type}/{asset_name}.v{schema_version}.avro.json"
-        return self.get_schema_from_path(key)

--- a/hyperion/domain/messages.py
+++ b/hyperion/domain/messages.py
@@ -1,0 +1,101 @@
+"""Domain message models and their SQS-envelope (de)serialization helpers.
+
+Pure domain: depends only on pydantic, the lite core and
+:mod:`hyperion.domain.assets`. ``aws_lambda_typing`` is a typing-only
+dependency (no boto3), so this module stays lite. Concrete queue adapters
+live in ``hyperion.adapters.queue.*``.
+"""
+
+import datetime
+from collections.abc import Iterator
+from enum import Enum
+from typing import ClassVar
+
+from aws_lambda_typing.events import SQSEvent
+
+# After a long consideration, I decided to use pydantic to serialize / deserialize the messages.
+# The convenience outweighs the performance hit.
+from pydantic import BaseModel, Field
+
+from hyperion.config import config
+from hyperion.dateutils import utcnow
+from hyperion.domain.assets import DataLakeAsset
+from hyperion.log import get_logger
+
+logger = get_logger("hyperion-queue")
+
+
+class ArrivalEvent(str, Enum):
+    ARRIVED = "arrived"
+
+
+class Message(BaseModel):
+    _subclasses: ClassVar[dict[str, type["Message"]]] = {}
+
+    def __init_subclass__(cls: type["Message"]) -> None:
+        cls._subclasses[cls.__name__] = cls
+
+    @staticmethod
+    def deserialize(json_str: str, message_type: str, receipt_handle: str | None = None) -> "Message":
+        msg = Message._subclasses[message_type].model_validate_json(json_str)
+        if receipt_handle and not msg.receipt_handle:
+            msg.receipt_handle = receipt_handle
+        return msg
+
+    created: datetime.datetime = Field(default_factory=utcnow)
+    sender: str = config.service_name
+    receipt_handle: str | None = None
+
+
+class DataLakeArrivalMessage(Message):
+    asset: DataLakeAsset
+    event: ArrivalEvent
+    schema_path: str | None = None
+
+
+class SourceBackfillMessage(Message):
+    source: str
+    start_date: datetime.datetime | datetime.date
+    end_date: datetime.datetime | datetime.date | None = None
+    notify: bool = True
+
+
+class SerializedMessage(BaseModel):
+    message_type: str
+    message: str
+
+
+def iter_messages_from_sqs_event(event: SQSEvent) -> Iterator[Message]:
+    if not isinstance(event, dict) or "Records" not in event or not isinstance(event["Records"], list):
+        raise ValueError("Provided event is not a valid SQS Event.")
+    for record in event["Records"]:
+        logger.info("Deserializing message.", message_id=record["messageId"])
+        if "MessageType" not in record["messageAttributes"]:
+            logger.warning("Message has no type and probably does not come from Hyperion.", message=record)
+            continue
+        message_type = record["messageAttributes"]["MessageType"]["stringValue"]
+        logger.debug("Attempting to deserialize message.", message=record, type=message_type)
+        yield Message.deserialize(record["body"], message_type, record["receiptHandle"])
+
+
+def create_backfill_event(
+    message: SourceBackfillMessage, message_id: str = "test", receipt_handle: str = ""
+) -> SQSEvent:
+    return {
+        "Records": [
+            {
+                "body": message.model_dump_json(),
+                "messageId": message_id,
+                "receiptHandle": receipt_handle,
+                "messageAttributes": {
+                    "MessageType": {
+                        "binaryListValues": [],
+                        "binaryValue": None,
+                        "dataType": "String",
+                        "stringListValues": [],
+                        "stringValue": "SourceBackfillMessage",
+                    }
+                },
+            }
+        ]
+    }

--- a/hyperion/infrastructure/cache.py
+++ b/hyperion/infrastructure/cache.py
@@ -1,22 +1,24 @@
-"""Concrete cache adapters.
+"""Deprecated import shim for cache adapters (still hosts ``PersistentCache``).
 
 .. deprecated::
     The abstract :class:`Cache`, :class:`CacheStats` and :class:`CachingError`
-    moved to :mod:`hyperion.ports.cache`. Import them from there. This module
-    keeps them importable (with a :class:`DeprecationWarning`) for the whole
-    ``hyperion-sdk`` 1.x line and still hosts the concrete adapters until S6.
+    moved to :mod:`hyperion.ports.cache`. The concrete adapters moved to
+    ``hyperion.adapters.cache.*`` (``InMemoryCache`` ->
+    :mod:`hyperion.adapters.cache.memory`, ``LocalFileCache`` ->
+    :mod:`hyperion.adapters.cache.filesystem`, ``DynamoDBCache`` ->
+    :mod:`hyperion.adapters.cache.dynamodb`). Import them from there. This
+    module keeps every relocated symbol importable (with a
+    :class:`DeprecationWarning`, resolved lazily so the import does not pull
+    boto3) for the whole ``hyperion-sdk`` 1.x line; symbols are removed in 2.0.
+
+    :class:`PersistentCache` is *not* relocated here -- it is the
+    ``Catalog`` <-> cache knot removed in step S7 and still lives in this
+    module until then.
 """
 
-import tempfile
-import time
+import importlib
 from base64 import b64decode, b64encode
-from collections.abc import Iterator
-from contextlib import contextmanager
-from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any, Literal, cast, overload
-
-import boto3
-import cachetools
+from typing import TYPE_CHECKING, Any
 
 from hyperion._compat import moved_attr
 from hyperion.catalog import AssetNotFoundError, Catalog
@@ -29,17 +31,30 @@ from hyperion.ports.cache import CacheStats as _CacheStats
 from hyperion.ports.cache import CachingError as _CachingError
 
 if TYPE_CHECKING:
+    from hyperion.adapters.cache.dynamodb import DYNAMODB_MAX_LENGTH, DynamoDBCache
+    from hyperion.adapters.cache.filesystem import DEFAULT_LOCAL_FILE_CACHE_MAX_SIZE, LocalFileCache
+    from hyperion.adapters.cache.memory import InMemoryCache
     from hyperion.ports.cache import Cache, CacheStats, CachingError
-
-DYNAMODB_MAX_LENGTH = 65535
-DEFAULT_LOCAL_FILE_CACHE_MAX_SIZE = 256 * (1024**2)
 
 logger = get_logger("cache")
 
+_OLD_MODULE = "hyperion.infrastructure.cache"
+
+# Abstract contract types -- already imported from the lite ``ports`` layer.
 _MOVED: dict[str, tuple[object, str]] = {
     "Cache": (_Cache, "hyperion.ports.cache"),
     "CacheStats": (_CacheStats, "hyperion.ports.cache"),
     "CachingError": (_CachingError, "hyperion.ports.cache"),
+}
+
+# Concrete adapters + their constants -- resolved lazily so importing this
+# shim never pulls boto3 (the DynamoDB adapter).
+_MOVED_LAZY: dict[str, str] = {
+    "InMemoryCache": "hyperion.adapters.cache.memory",
+    "LocalFileCache": "hyperion.adapters.cache.filesystem",
+    "DEFAULT_LOCAL_FILE_CACHE_MAX_SIZE": "hyperion.adapters.cache.filesystem",
+    "DynamoDBCache": "hyperion.adapters.cache.dynamodb",
+    "DYNAMODB_MAX_LENGTH": "hyperion.adapters.cache.dynamodb",
 }
 
 __all__ = [
@@ -60,209 +75,12 @@ __all__ = [
 def __getattr__(name: str) -> object:
     if name in _MOVED:
         value, new_module = _MOVED[name]
-        return moved_attr(
-            name=name, value=value, old_module="hyperion.infrastructure.cache", new_module=new_module
-        )
+        return moved_attr(name=name, value=value, old_module=_OLD_MODULE, new_module=new_module)
+    if name in _MOVED_LAZY:
+        new_module = _MOVED_LAZY[name]
+        module = importlib.import_module(new_module)
+        return moved_attr(name=name, value=getattr(module, name), old_module=_OLD_MODULE, new_module=new_module)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-class InMemoryCache(_Cache):
-    """An in-memory cache for our shenanigans."""
-
-    MAX_KEYS = 1000
-    cache: cachetools.TTLCache[str, str]
-
-    def __init__(
-        self, prefix: str, hash_keys: bool = True, default_ttl: int = DEFAULT_TTL_SECONDS, max_size: int = MAX_KEYS
-    ):
-        super().__init__(prefix, hash_keys, default_ttl)
-        self.max_size = max_size
-        self.cache = cachetools.TTLCache[str, str](maxsize=self.max_size, ttl=self.default_ttl)
-
-    def _get(self, key: str) -> str | None:
-        return self.cache.get(self._key(key))
-
-    def _set(self, key: str, value: str) -> None:
-        self.cache[self._key(key)] = value
-
-    def _set_bytes(self, key: str, value: bytes) -> None:
-        self.cache[self._key(key)] = b64encode(value).decode("ascii")
-
-    def _get_bytes(self, key: str) -> bytes | None:
-        if (cached := self.cache.get(self._key(key))) is None:
-            return None
-        try:
-            return b64decode(cached.encode("ascii"))
-        except Exception as error:
-            raise _CachingError(f"Failed to decode cached key {key!r}, make sure it was stored as bytes.") from error
-
-    def _delete(self, key: str) -> None:
-        self.cache.pop(self._key(key), None)
-
-    def _clear(self) -> None:
-        self.cache.clear()
-
-    def _hit(self, key: str) -> bool:
-        return self._key(key) in self.cache
-
-
-class LocalFileCache(_Cache):
-    """A local file cache for our shenanigans."""
-
-    def __init__(
-        self,
-        prefix: str,
-        hash_keys: bool = True,
-        default_ttl: int = DEFAULT_TTL_SECONDS,
-        root_path: Path | None = None,
-        max_size: int | None = DEFAULT_LOCAL_FILE_CACHE_MAX_SIZE,
-        use_compression: bool = True,
-    ) -> None:
-        super().__init__(prefix, hash_keys, default_ttl)
-        self.root_path = root_path or Path(tempfile.mkdtemp())
-        if self.root_path.exists() and not self.root_path.is_dir():
-            raise ValueError(f"Given local cache path ({self.root_path.as_posix()}) is not a directory.")
-        self.use_compression = use_compression
-        self.max_size = max_size
-        self._assert_root_path()
-        logger.info(f"Initialized LocalFileCache in {self.root_path.as_posix()}.", root_path=self.root_path.as_posix())
-        if not hash_keys:
-            logger.warning("When using filesystem cache, it is recommended to hash keys.")
-        self.shrink_to_fit_max_size()
-
-    def _assert_root_path(self) -> None:
-        self.root_path.mkdir(parents=True, exist_ok=True)
-
-    def _cleanup(self) -> None:
-        """Clean up all expired files from the cache."""
-        self._assert_root_path()
-        for key_path in self.root_path.iterdir():
-            if key_path.is_file() and self._is_expired(key_path):
-                logger.debug("Cleaning up expired file.", key_path=key_path)
-                key_path.unlink()
-
-    def get_total_size(self) -> int:
-        self._assert_root_path()
-        return sum(key_path.stat().st_size for key_path in self.root_path.iterdir() if key_path.is_file())
-
-    @overload
-    @contextmanager
-    def _open(self, key: str, mode: Literal["str"]) -> Iterator[IO[str]]:
-        pass
-
-    @overload
-    @contextmanager
-    def _open(self, key: str, mode: Literal["bytes"]) -> Iterator[IO[bytes]]:
-        pass
-
-    @contextmanager
-    def _open(self, key: str, mode: CacheKeyOpenMode = "str") -> Iterator[IO[str] | IO[bytes]]:
-        self.hit(key)  # this should expire the file if needed
-        if self.use_compression:
-            logger.warning(
-                "Current LocalFileCache implementation does not work well with compression on. "
-                "It compresses the content in-memory. For now, you should consider using "
-                "use_compression=False and utilizing e.g. snappy or gzip manually."
-            )
-            with super()._open(key, mode) as file:
-                yield file
-            return
-        key_path = self._key_path(key)
-        key_path.touch(exist_ok=True)
-        if mode == "str":
-            with key_path.open("a+") as file:
-                file.seek(0)
-                yield file
-        elif mode == "bytes":
-            with key_path.open("a+b") as file:
-                file.seek(0)
-                yield file
-        else:
-            raise ValueError(f"Unsupported open mode {mode!r} - 'str' or 'bytes' are supported.")
-        if not key_path.stat().st_size:
-            key_path.unlink(missing_ok=True)
-
-    def shrink_to_fit_max_size(self) -> None:
-        self._cleanup()
-        if not self.max_size or self.max_size < 0:
-            return
-        total_size = self.get_total_size()
-        keys_ordered = sorted(self.root_path.iterdir(), key=lambda key: key.stat().st_mtime)
-        while total_size > self.max_size:
-            key_path = keys_ordered.pop(0)
-            if not key_path.is_file():
-                continue
-            size = key_path.stat().st_size
-            logger.debug("Cleaning up old file to make some space.", key_path=key_path, size=size)
-            key_path.unlink()
-            total_size -= size
-
-    def _key_path(self, key: str) -> Path:
-        return self.root_path / self._key(key)
-
-    def _is_expired(self, key: str | Path) -> bool:
-        self._assert_root_path()
-        if isinstance(key, str):
-            key = self._key_path(key)
-        current_time = time.time()
-        return (current_time - key.stat().st_mtime) > self.default_ttl
-
-    def _get(self, key: str) -> str | None:
-        if (cached := self._get_bytes(key)) is None:
-            return None
-        return cached.decode("utf-8")
-
-    def _get_bytes(self, key: str) -> bytes | None:
-        self._assert_root_path()
-        if not self.hit(key):
-            return None
-        key_path = self._key_path(key)
-        logger.debug("Reading key from file.", key=key, path=key_path.as_posix())
-        content = key_path.read_bytes()
-        if self.use_compression:
-            return self._decompress_bytes(content)
-        return content
-
-    def _perform_set(self, key: str, value: str | bytes) -> None:
-        self._assert_root_path()
-        key_path = self._key_path(key)
-        logger.debug("Storing key into a file.", key=key, path=key_path.as_posix())
-        if isinstance(value, str):
-            value = value.encode("utf-8")
-        content = self._compress_bytes(value) if self.use_compression else value
-        key_path.write_bytes(content)
-
-    def _set(self, key: str, value: str) -> None:
-        return self._perform_set(key, value)
-
-    def _set_bytes(self, key: str, value: bytes) -> None:
-        return self._perform_set(key, value)
-
-    def _delete(self, key: str) -> None:
-        self._assert_root_path()
-        key_path = self._key_path(key)
-        if not key_path.exists():
-            return None
-        logger.debug("Removing cached key.", key=key, path=key_path.as_posix())
-        key_path.unlink()
-
-    def _hit(self, key: str) -> bool:
-        key_path = self._key_path(key)
-        if not key_path.exists():
-            return False
-        if self._is_expired(key_path):
-            logger.debug("Key is expired, deleting file.", key=key, key_path=key_path)
-            key_path.unlink()
-            return False
-        return True
-
-    def _clear(self) -> None:
-        self._assert_root_path()
-        for file in self.root_path.iterdir():
-            if not file.is_file():
-                continue
-            logger.debug("Removing cached key.", path=file.as_posix())
-            file.unlink()
 
 
 class PersistentCache(_Cache):
@@ -358,75 +176,3 @@ class PersistentCache(_Cache):
 
     def _hit(self, key: str) -> bool:
         return self._key(key) in self.data
-
-
-class DynamoDBCache(_Cache):
-    """A DynamoDB cache for our shenanigans."""
-
-    TTL_ATTRIBUTE_NAME = "time_to_live"
-
-    def __init__(
-        self, prefix: str, hash_keys: bool = True, default_ttl: int = DEFAULT_TTL_SECONDS, table_name: str | None = None
-    ):
-        super().__init__(prefix, hash_keys, default_ttl)
-        self.client = boto3.resource("dynamodb")
-        if table_name is None:
-            raise ValueError("No table_name was provided for DynamoDBCache.")
-        self.table_name = table_name
-        self.table = self.client.Table(table_name)
-
-    def _get(self, key: str) -> str | None:
-        if (cached := self._get_bytes(key)) is None:
-            return None
-        return cached.decode("utf-8")
-
-    def _set(self, key: str, value: str) -> None:
-        return self._set_bytes(key, value.encode("utf-8"))
-
-    def _set_bytes(self, key: str, value: bytes) -> None:
-        expiration_time = int(time.time()) + self.default_ttl
-        cache_key = self._key(key)
-        compressed_value = self._compress_bytes(value)
-        if len(compressed_value) > DYNAMODB_MAX_LENGTH:
-            logger.warning(
-                "Value is too long to store in DynamoDB.",
-                original_key=cache_key,
-                cache_key=cache_key,
-                length=len(compressed_value),
-            )
-            raise _CachingError(f"Value is too long to store in DynamoDB: {len(compressed_value)}")
-        self.table.put_item(
-            Item={"key": cache_key, "value": compressed_value, self.TTL_ATTRIBUTE_NAME: expiration_time}
-        )
-
-    def _get_bytes(self, key: str) -> bytes | None:
-        cache_key = self._key(key)
-        response = self.table.get_item(Key={"key": cache_key})
-        item = response.get("Item")
-        if item:
-            return self._decompress_bytes(bytes(cast(Any, item["value"])))
-        return None
-
-    def _delete(self, key: str) -> None:
-        key = self._key(key)
-        self.table.delete_item(Key={"key": key})
-
-    def _clear(self) -> None:
-        """
-        Deletes all items in the table.
-
-        Warning: DynamoDB doesn't have a built-in clear mechanism, so we scan and delete all items manually.
-        """
-        logger.info("Clearing cache.", cache_table=self.table_name)
-        scan = self.table.scan()
-        with self.table.batch_writer() as batch:
-            for item in scan["Items"]:
-                batch.delete_item(Key={"key": item["key"]})
-
-    def _hit(self, key: str) -> bool:
-        cache_key = self._key(key)
-        item = self.table.get_item(Key={"key": cache_key}, ProjectionExpression=self.TTL_ATTRIBUTE_NAME).get("Item")
-        if not item:
-            return False
-        item_ttl = int(cast(Any, item.get(self.TTL_ATTRIBUTE_NAME) or 0))
-        return bool(item and item_ttl > int(time.time()))

--- a/hyperion/infrastructure/httputils.py
+++ b/hyperion/infrastructure/httputils.py
@@ -1,41 +1,36 @@
-from urllib.parse import urlparse
+"""Deprecated import shim for HTTP proxy helpers.
 
-import httpx
+.. deprecated::
+    :func:`redact_url` and :func:`get_proxy_mounts` moved to
+    :mod:`hyperion.adapters.http.proxy`. Import them from there. This module
+    keeps them importable (with a :class:`DeprecationWarning`, resolved lazily)
+    for the whole ``hyperion-sdk`` 1.x line. The symbols are removed in 2.0.
+"""
 
-from hyperion.config import http_config
-from hyperion.log import get_logger
+import importlib
+from typing import TYPE_CHECKING
 
-logger = get_logger("hyperion-http")
+from hyperion._compat import moved_attr
+
+if TYPE_CHECKING:
+    from hyperion.adapters.http.proxy import get_proxy_mounts, redact_url
+
+_OLD_MODULE = "hyperion.infrastructure.httputils"
+
+_MOVED_LAZY: dict[str, str] = {
+    "redact_url": "hyperion.adapters.http.proxy",
+    "get_proxy_mounts": "hyperion.adapters.http.proxy",
+}
+
+__all__ = [
+    "get_proxy_mounts",
+    "redact_url",
+]
 
 
-def redact_url(url: str, replace: str = "***") -> str:
-    """Replace password from {url} (if any) with {replace}.
-    If the url contains no password, url is returned unchanged.
-    """
-    parsed = urlparse(url)
-    if parsed.password:
-        return parsed._replace(netloc=f"{parsed.username}:{replace}@{parsed.hostname}").geturl()
-    return url
-
-
-def get_proxy_mounts() -> dict[str, httpx.AsyncHTTPTransport]:
-    """Build httpx proxy mounts from HYPERION_HTTP_PROXY_HTTP / HYPERION_HTTP_PROXY_HTTPS env vars.
-
-    If only one of the two is set, it is used for both http:// and https://.
-    """
-    proxy_mounts: dict[str, httpx.AsyncHTTPTransport] = {}
-    if http_config.proxy_http:
-        redacted_url = redact_url(http_config.proxy_http)
-        logger.info("Configuring HTTP proxy for http://", proxy_url=redacted_url)
-        proxy_mounts["http://"] = httpx.AsyncHTTPTransport(proxy=http_config.proxy_http)
-        if not http_config.proxy_https:
-            logger.info("Configuring HTTP proxy for https://", proxy_url=redacted_url)
-            proxy_mounts["https://"] = httpx.AsyncHTTPTransport(proxy=http_config.proxy_http)
-    if http_config.proxy_https:
-        redacted_url = redact_url(http_config.proxy_https)
-        logger.info("Configuring HTTP proxy for https://", proxy_url=redacted_url)
-        proxy_mounts["https://"] = httpx.AsyncHTTPTransport(proxy=http_config.proxy_https)
-        if not http_config.proxy_http:
-            logger.info("Configuring HTTP proxy for http://", proxy_url=redacted_url)
-            proxy_mounts["http://"] = httpx.AsyncHTTPTransport(proxy=http_config.proxy_https)
-    return proxy_mounts
+def __getattr__(name: str) -> object:
+    if name in _MOVED_LAZY:
+        new_module = _MOVED_LAZY[name]
+        module = importlib.import_module(new_module)
+        return moved_attr(name=name, value=getattr(module, name), old_module=_OLD_MODULE, new_module=new_module)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/hyperion/infrastructure/keyval.py
+++ b/hyperion/infrastructure/keyval.py
@@ -1,32 +1,43 @@
-"""Concrete key-value store adapters.
-
-If you need a store with a TTL, look at :class:`hyperion.ports.cache.Cache`
-instead.
+"""Deprecated import shim for key-value store adapters.
 
 .. deprecated::
-    The abstract :class:`KeyValueStore` and the :data:`CompressionType` alias
-    moved to :mod:`hyperion.ports.keyval`. Import them from there. This module
-    keeps them importable (with a :class:`DeprecationWarning`) for the whole
-    ``hyperion-sdk`` 1.x line and still hosts the concrete adapters until S6.
+    The abstract :class:`KeyValueStore`, the :data:`CompressionType` alias and
+    the :func:`is_valid_compression_type` guard moved to
+    :mod:`hyperion.ports.keyval`. The concrete adapters moved to
+    ``hyperion.adapters.keyval.*`` (``InMemoryStore`` ->
+    :mod:`hyperion.adapters.keyval.memory`, ``DynamoDBStore`` ->
+    :mod:`hyperion.adapters.keyval.dynamodb`). Import them from there. This
+    module keeps every symbol importable (with a :class:`DeprecationWarning`,
+    resolved lazily so the import does not pull boto3) for the whole
+    ``hyperion-sdk`` 1.x line. The symbols are removed in 2.0.
 """
 
-from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, TypeGuard, cast
-
-import boto3
+import importlib
+from typing import TYPE_CHECKING
 
 from hyperion._compat import moved_attr
 from hyperion.ports.keyval import CompressionType as _CompressionType
 from hyperion.ports.keyval import KeyValueStore as _KeyValueStore
+from hyperion.ports.keyval import is_valid_compression_type as _is_valid_compression_type
 
 if TYPE_CHECKING:
-    from mypy_boto3_dynamodb.type_defs import ScanInputTableScanTypeDef
+    from hyperion.adapters.keyval.dynamodb import DynamoDBStore
+    from hyperion.adapters.keyval.memory import InMemoryStore
+    from hyperion.ports.keyval import CompressionType, KeyValueStore, is_valid_compression_type
 
-    from hyperion.ports.keyval import CompressionType, KeyValueStore
+_OLD_MODULE = "hyperion.infrastructure.keyval"
 
+# Symbols already imported here from the lite ``ports`` layer -- returned eagerly.
 _MOVED: dict[str, tuple[object, str]] = {
     "KeyValueStore": (_KeyValueStore, "hyperion.ports.keyval"),
     "CompressionType": (_CompressionType, "hyperion.ports.keyval"),
+    "is_valid_compression_type": (_is_valid_compression_type, "hyperion.ports.keyval"),
+}
+
+# Concrete adapters -- resolved lazily so importing this shim stays boto3-free.
+_MOVED_LAZY: dict[str, str] = {
+    "InMemoryStore": "hyperion.adapters.keyval.memory",
+    "DynamoDBStore": "hyperion.adapters.keyval.dynamodb",
 }
 
 __all__ = [
@@ -41,87 +52,9 @@ __all__ = [
 def __getattr__(name: str) -> object:
     if name in _MOVED:
         value, new_module = _MOVED[name]
-        return moved_attr(
-            name=name, value=value, old_module="hyperion.infrastructure.keyval", new_module=new_module
-        )
+        return moved_attr(name=name, value=value, old_module=_OLD_MODULE, new_module=new_module)
+    if name in _MOVED_LAZY:
+        new_module = _MOVED_LAZY[name]
+        module = importlib.import_module(new_module)
+        return moved_attr(name=name, value=getattr(module, name), old_module=_OLD_MODULE, new_module=new_module)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def is_valid_compression_type(compression_type: str) -> TypeGuard[_CompressionType]:
-    return compression_type in ("snappy", "gzip")
-
-
-class DynamoDBStore(_KeyValueStore):
-    """A key-value store using DynamoDB.
-
-    The table must have a key attribute and a value attribute.
-    """
-
-    def __init__(
-        self,
-        prefix: str | None = None,
-        compression: _CompressionType | None = None,
-        table_name: str | None = None,
-        key_attribute: str = "key",
-        value_attribute: str = "value",
-    ):
-        super().__init__(prefix, compression)
-        self.client = boto3.resource("dynamodb")
-        if table_name is None:
-            raise ValueError("No table name provided for DynamoDBStore.")
-        self.table_name = table_name
-        self.table = self.client.Table(self.table_name)
-        self.key_attribute = key_attribute
-        self.value_attribute = value_attribute
-
-    def _get_raw(self, hashed_key: str) -> bytes | None:
-        response = self.table.get_item(Key={self.key_attribute: hashed_key})
-        item = response.get("Item")
-        if not item:
-            return None
-        return bytes(cast(Any, item[self.value_attribute]))
-
-    def _set_raw(self, hashed_key: str, compresed_value: bytes) -> None:
-        self.table.put_item(Item={self.key_attribute: hashed_key, self.value_attribute: compresed_value})
-
-    def _delete_raw(self, hashed_key: str) -> None:
-        self.table.delete_item(Key={self.key_attribute: hashed_key})
-
-    def _iter_all_keys(self) -> Iterable[str]:
-        scan_kwargs: ScanInputTableScanTypeDef = {
-            "ProjectionExpression": "#k",
-            "ExpressionAttributeNames": {"#k": self.key_attribute},
-        }
-        while True:
-            response = self.table.scan(**scan_kwargs)
-            for item in response.get("Items", []):
-                key = str(item[self.key_attribute])
-                if self.prefix:
-                    key = key.replace(f"{self.prefix}:", "", 1)
-                yield key
-            if "LastEvaluatedKey" not in response:
-                break
-            scan_kwargs["ExclusiveStartKey"] = response["LastEvaluatedKey"]
-
-
-class InMemoryStore(_KeyValueStore):
-    """An in-memory key-value store.
-
-    This store is not persistent and is not shared between instances.
-    """
-
-    def __init__(self, prefix: str | None = None, compression: _CompressionType | None = None):
-        super().__init__(prefix, compression)
-        self.store: dict[str, bytes] = {}
-
-    def _get_raw(self, hashed_key: str) -> bytes | None:
-        return self.store.get(hashed_key)
-
-    def _set_raw(self, hashed_key: str, compresed_value: bytes) -> None:
-        self.store[hashed_key] = compresed_value
-
-    def _delete_raw(self, hashed_key: str) -> None:
-        self.store.pop(hashed_key, None)
-
-    def _iter_all_keys(self) -> Iterable[str]:
-        yield from self.store

--- a/hyperion/infrastructure/message_queue.py
+++ b/hyperion/infrastructure/message_queue.py
@@ -1,49 +1,56 @@
-"""Message models and concrete queue adapters.
+"""Deprecated import shim for message models and queue adapters.
 
 .. deprecated::
-    The abstract :class:`Queue` moved to :mod:`hyperion.ports.queue`. Import it
-    from there. This module keeps it importable (with a
-    :class:`DeprecationWarning`) for the whole ``hyperion-sdk`` 1.x line and
-    still hosts the message models and concrete adapters until S6.
+    The abstract :class:`Queue` moved to :mod:`hyperion.ports.queue`. The
+    message models and their SQS-envelope helpers moved to
+    :mod:`hyperion.domain.messages`. The concrete adapters moved to
+    ``hyperion.adapters.queue.*`` (``InMemoryQueue`` ->
+    :mod:`hyperion.adapters.queue.memory`, ``FileQueue`` ->
+    :mod:`hyperion.adapters.queue.filesystem`, ``SQSQueue`` ->
+    :mod:`hyperion.adapters.queue.sqs`). Import them from there. This module
+    keeps every symbol importable (with a :class:`DeprecationWarning`,
+    resolved lazily so the import does not pull boto3) for the whole
+    ``hyperion-sdk`` 1.x line. The symbols are removed in 2.0.
 """
 
-import datetime
-import json
-import shutil
-import sys
-import tempfile
-from collections.abc import Iterator
-from enum import Enum
-from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar
-
-from aws_lambda_typing.events import SQSEvent
-from boto3 import client
-
-# After a long consideration, I decided to use pydantic to serialize / deserialize the messages.
-# The convenience outweighs the performance hit.
-from pydantic import BaseModel, Field
+import importlib
+from typing import TYPE_CHECKING
 
 from hyperion._compat import moved_attr
-from hyperion.config import config
-from hyperion.dateutils import utcnow
-from hyperion.domain.assets import DataLakeAsset
-from hyperion.log import get_logger
 from hyperion.ports.queue import Queue as _Queue
 
-if sys.version_info >= (3, 11) and TYPE_CHECKING:
-    from typing import Self
-
-if sys.version_info < (3, 11) and TYPE_CHECKING:
-    from typing_extensions import Self
-
 if TYPE_CHECKING:
+    from hyperion.adapters.queue.filesystem import FileQueue
+    from hyperion.adapters.queue.memory import InMemoryQueue
+    from hyperion.adapters.queue.sqs import SQSQueue
+    from hyperion.domain.messages import (
+        ArrivalEvent,
+        DataLakeArrivalMessage,
+        Message,
+        SerializedMessage,
+        SourceBackfillMessage,
+        create_backfill_event,
+        iter_messages_from_sqs_event,
+    )
     from hyperion.ports.queue import Queue
 
-logger = get_logger("hyperion-queue")
+_OLD_MODULE = "hyperion.infrastructure.message_queue"
 
 _MOVED: dict[str, tuple[object, str]] = {
     "Queue": (_Queue, "hyperion.ports.queue"),
+}
+
+_MOVED_LAZY: dict[str, str] = {
+    "ArrivalEvent": "hyperion.domain.messages",
+    "Message": "hyperion.domain.messages",
+    "DataLakeArrivalMessage": "hyperion.domain.messages",
+    "SourceBackfillMessage": "hyperion.domain.messages",
+    "SerializedMessage": "hyperion.domain.messages",
+    "iter_messages_from_sqs_event": "hyperion.domain.messages",
+    "create_backfill_event": "hyperion.domain.messages",
+    "InMemoryQueue": "hyperion.adapters.queue.memory",
+    "FileQueue": "hyperion.adapters.queue.filesystem",
+    "SQSQueue": "hyperion.adapters.queue.sqs",
 }
 
 __all__ = [
@@ -64,198 +71,9 @@ __all__ = [
 def __getattr__(name: str) -> object:
     if name in _MOVED:
         value, new_module = _MOVED[name]
-        return moved_attr(
-            name=name, value=value, old_module="hyperion.infrastructure.message_queue", new_module=new_module
-        )
+        return moved_attr(name=name, value=value, old_module=_OLD_MODULE, new_module=new_module)
+    if name in _MOVED_LAZY:
+        new_module = _MOVED_LAZY[name]
+        module = importlib.import_module(new_module)
+        return moved_attr(name=name, value=getattr(module, name), old_module=_OLD_MODULE, new_module=new_module)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-class ArrivalEvent(str, Enum):
-    ARRIVED = "arrived"
-
-
-class Message(BaseModel):
-    _subclasses: ClassVar[dict[str, type["Message"]]] = {}
-
-    def __init_subclass__(cls: type["Message"]) -> None:
-        cls._subclasses[cls.__name__] = cls
-
-    @staticmethod
-    def deserialize(json_str: str, message_type: str, receipt_handle: str | None = None) -> "Message":
-        msg = Message._subclasses[message_type].model_validate_json(json_str)
-        if receipt_handle and not msg.receipt_handle:
-            msg.receipt_handle = receipt_handle
-        return msg
-
-    created: datetime.datetime = Field(default_factory=utcnow)
-    sender: str = config.service_name
-    receipt_handle: str | None = None
-
-
-class DataLakeArrivalMessage(Message):
-    asset: DataLakeAsset
-    event: ArrivalEvent
-    schema_path: str | None = None
-
-
-class SourceBackfillMessage(Message):
-    source: str
-    start_date: datetime.datetime | datetime.date
-    end_date: datetime.datetime | datetime.date | None = None
-    notify: bool = True
-
-
-class SerializedMessage(BaseModel):
-    message_type: str
-    message: str
-
-
-def iter_messages_from_sqs_event(event: SQSEvent) -> Iterator[Message]:
-    if not isinstance(event, dict) or "Records" not in event or not isinstance(event["Records"], list):
-        raise ValueError("Provided event is not a valid SQS Event.")
-    for record in event["Records"]:
-        logger.info("Deserializing message.", message_id=record["messageId"])
-        if "MessageType" not in record["messageAttributes"]:
-            logger.warning("Message has no type and probably does not come from Hyperion.", message=record)
-            continue
-        message_type = record["messageAttributes"]["MessageType"]["stringValue"]
-        logger.debug("Attempting to deserialize message.", message=record, type=message_type)
-        yield Message.deserialize(record["body"], message_type, record["receiptHandle"])
-
-
-def create_backfill_event(
-    message: SourceBackfillMessage, message_id: str = "test", receipt_handle: str = ""
-) -> SQSEvent:
-    return {
-        "Records": [
-            {
-                "body": message.model_dump_json(),
-                "messageId": message_id,
-                "receiptHandle": receipt_handle,
-                "messageAttributes": {
-                    "MessageType": {
-                        "binaryListValues": [],
-                        "binaryValue": None,
-                        "dataType": "String",
-                        "stringListValues": [],
-                        "stringValue": "SourceBackfillMessage",
-                    }
-                },
-            }
-        ]
-    }
-
-
-class InMemoryQueue(_Queue):
-    def __init__(self) -> None:
-        super().__init__()
-        self._messages: list[Message] = []
-
-    def send(self, message: Message) -> None:
-        self._messages.append(message)
-
-    def delete(self, receipt_handle: str) -> None:
-        """Delete the message using the created as isoformat."""
-        for message in self._messages:
-            if message.created.isoformat() == receipt_handle:
-                self._messages.remove(message)
-                break
-
-
-class SQSQueue(_Queue):
-    def __init__(self, queue_url: str) -> None:
-        super().__init__()
-        self._queue_url = queue_url
-        self._client = client("sqs")
-
-    def send(self, message: Message) -> None:
-        self._client.send_message(
-            QueueUrl=self._queue_url,
-            MessageBody=message.model_dump_json(),
-            MessageAttributes={
-                "MessageType": {
-                    "DataType": "String",
-                    "StringValue": message.__class__.__name__,
-                }
-            },
-        )
-
-    def delete(self, receipt_handle: str) -> None:
-        self._client.delete_message(QueueUrl=self._queue_url, ReceiptHandle=receipt_handle)
-
-    def __repr__(self) -> str:
-        return f"<{self.__class__.__name__} {self._queue_url}>"
-
-
-class FileQueue(_Queue):
-    def __init__(self, queue_path: Path, *, overwrite: bool = False, exclusive: bool = False) -> None:
-        """File-based message queue.
-
-        If the queue is exclusive and it is entered multiple times, a RuntimeError will be raised.
-
-        Args:
-            queue_path (Path): The path to the queue file.
-            overwrite (bool, optional): Whether to overwrite the queue file if it exists. Defaults to False.
-            exclusive (bool, optional): Whether to use exclusive access to the queue file. Defaults to False.
-        """
-        self._messages: list[Message] = []
-        self._context_stacklevel = 0
-        self._exclusive = exclusive
-        self.queue_path = queue_path.resolve()
-        super().__init__()
-        if queue_path.exists():
-            if not queue_path.resolve().is_file():
-                raise FileExistsError(f"Queue path {queue_path} already exists and is not a file.")
-            if not overwrite:
-                raise FileExistsError(f"Queue path {queue_path} already exists, set overwrite=True to ignore this.")
-            logger.warning("Queue path already exists, it will be overwritten.", queue_path=queue_path, queue=self)
-
-    def send(self, message: Message) -> None:
-        if self._context_stacklevel == 0:
-            logger.warning("Using FileQueue outside of a context manager does not persist the messages.", queue=self)
-        self._messages.append(message)
-
-    def delete(self, receipt_handle: str) -> None:
-        raise NotImplementedError("FileQueue does not implement message deletion.")
-
-    def _flush(self) -> None:
-        serializable_list = [
-            {"message_type": message.__class__.__name__, "message": message.model_dump_json()}
-            for message in self._messages
-        ]
-        with tempfile.NamedTemporaryFile("w", delete=False) as tmp_file:
-            json.dump(serializable_list, tmp_file)
-        shutil.move(tmp_file.name, self.queue_path)
-        logger.info(
-            f"Flushed {len(self._messages)} from FileQueue.",
-            queue=self,
-            messages=len(self._messages),
-            queue_path=self.queue_path,
-        )
-        self._messages.clear()
-
-    def __repr__(self) -> str:
-        return f"<{self.__class__.__name__} at {hex(id(self))} exclusive={self._exclusive} path={self.queue_path}>"
-
-    def __enter__(self) -> "Self":
-        if self._exclusive and self._context_stacklevel != 0:
-            raise RuntimeError(
-                "FileQueue's context has already been entered, this cannot be done twice in exclusive mode."
-            )
-        self._context_stacklevel += 1
-        return self
-
-    def __exit__(self, *args: Any, **kwargs: Any) -> None:
-        self._context_stacklevel -= 1
-        if self._context_stacklevel != 0:
-            logger.info("FileQueue's context was exited, but there is still an open context somewhere, skipping flush.")
-            return
-        self._flush()
-
-    @staticmethod
-    def iter_messages_from_file(queue_file: Path) -> Iterator[Message]:
-        with queue_file.open("r", encoding="utf-8") as file:
-            raw_messages = json.load(file)
-        for raw_message in raw_messages:
-            serialized_message = SerializedMessage.model_validate(raw_message)
-            yield Message.deserialize(serialized_message.message, serialized_message.message_type)

--- a/hyperion/infrastructure/secretsmanager.py
+++ b/hyperion/infrastructure/secretsmanager.py
@@ -1,29 +1,38 @@
-"""Concrete secrets manager adapters.
+"""Deprecated import shim for secrets manager adapters.
 
 .. deprecated::
     The abstract :class:`SecretsManager` and :data:`SECRET_PATTERN` moved to
-    :mod:`hyperion.ports.secrets`. Import them from there. This module keeps
-    them importable (with a :class:`DeprecationWarning`) for the whole
-    ``hyperion-sdk`` 1.x line and still hosts the concrete adapters until S6.
+    :mod:`hyperion.ports.secrets`. The concrete adapters moved to
+    ``hyperion.adapters.secrets.*`` (``DummySecretsManager`` ->
+    :mod:`hyperion.adapters.secrets.dummy`, ``AWSSecretsManager`` ->
+    :mod:`hyperion.adapters.secrets.aws_sm`). Import them from there. This
+    module keeps every symbol importable (with a :class:`DeprecationWarning`,
+    resolved lazily so the import does not pull boto3) for the whole
+    ``hyperion-sdk`` 1.x line. The symbols are removed in 2.0.
 """
 
-from typing import TYPE_CHECKING, cast
-
-import boto3
+import importlib
+from typing import TYPE_CHECKING
 
 from hyperion._compat import moved_attr
-from hyperion.log import get_logger
 from hyperion.ports.secrets import SECRET_PATTERN as _SECRET_PATTERN
 from hyperion.ports.secrets import SecretsManager as _SecretsManager
 
 if TYPE_CHECKING:
+    from hyperion.adapters.secrets.aws_sm import AWSSecretsManager
+    from hyperion.adapters.secrets.dummy import DummySecretsManager
     from hyperion.ports.secrets import SECRET_PATTERN, SecretsManager
 
-logger = get_logger("hyperion-secrets")
+_OLD_MODULE = "hyperion.infrastructure.secretsmanager"
 
 _MOVED: dict[str, tuple[object, str]] = {
     "SecretsManager": (_SecretsManager, "hyperion.ports.secrets"),
     "SECRET_PATTERN": (_SECRET_PATTERN, "hyperion.ports.secrets"),
+}
+
+_MOVED_LAZY: dict[str, str] = {
+    "DummySecretsManager": "hyperion.adapters.secrets.dummy",  # pragma: allowlist secret
+    "AWSSecretsManager": "hyperion.adapters.secrets.aws_sm",  # pragma: allowlist secret
 }
 
 __all__ = [
@@ -37,21 +46,9 @@ __all__ = [
 def __getattr__(name: str) -> object:
     if name in _MOVED:
         value, new_module = _MOVED[name]
-        return moved_attr(
-            name=name, value=value, old_module="hyperion.infrastructure.secretsmanager", new_module=new_module
-        )
+        return moved_attr(name=name, value=value, old_module=_OLD_MODULE, new_module=new_module)
+    if name in _MOVED_LAZY:
+        new_module = _MOVED_LAZY[name]
+        module = importlib.import_module(new_module)
+        return moved_attr(name=name, value=getattr(module, name), old_module=_OLD_MODULE, new_module=new_module)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-class DummySecretsManager(_SecretsManager):
-    def get_secret(self, secret_name: str) -> str:
-        logger.warning("Using dummy secrets manager, no values will be returned.", secret_name=secret_name)
-        return ""
-
-
-class AWSSecretsManager(_SecretsManager):
-    def __init__(self) -> None:
-        self.client = boto3.client("secretsmanager")
-
-    def get_secret(self, secret_name: str) -> str:
-        return cast(str, self.client.get_secret_value(SecretId=secret_name)["SecretString"])

--- a/hyperion/ports/cache.py
+++ b/hyperion/ports/cache.py
@@ -2,8 +2,9 @@
 
 Abstract :class:`Cache` base plus its contract types (:class:`CacheStats`,
 :class:`CachingError`). Concrete adapters (``InMemoryCache``, ``LocalFileCache``,
-``DynamoDBCache``, ``PersistentCache``) live in ``hyperion.infrastructure.cache``
-until step S6; ``Cache.from_config`` reaches them via a deferred import.
+``DynamoDBCache``) live in ``hyperion.adapters.cache.*``; ``Cache.from_config``
+reaches them via a deferred import. ``PersistentCache`` still lives in
+``hyperion.infrastructure.cache`` until step S7.
 """
 
 import hashlib
@@ -75,7 +76,9 @@ class Cache(ABC):
         Returns:
             Cache: A cache instance.
         """
-        from hyperion.infrastructure.cache import DynamoDBCache, InMemoryCache, LocalFileCache
+        from hyperion.adapters.cache.dynamodb import DynamoDBCache
+        from hyperion.adapters.cache.filesystem import LocalFileCache
+        from hyperion.adapters.cache.memory import InMemoryCache
 
         instance_key = (storage_config.cache_key_prefix, True)
         if instance_key not in Cache._instances:

--- a/hyperion/ports/keyval.py
+++ b/hyperion/ports/keyval.py
@@ -1,21 +1,25 @@
 """Port: key-value store abstraction.
 
-Abstract :class:`KeyValueStore` base and the :data:`CompressionType` alias.
-If you need a store with a TTL, look at :class:`hyperion.ports.cache.Cache`
-instead. Concrete adapters (``DynamoDBStore``, ``InMemoryStore``) and the
-``is_valid_compression_type`` guard live in ``hyperion.infrastructure.keyval``
-until step S6.
+Abstract :class:`KeyValueStore` base, the :data:`CompressionType` alias and
+the :func:`is_valid_compression_type` guard. If you need a store with a TTL,
+look at :class:`hyperion.ports.cache.Cache` instead. Concrete adapters
+(``DynamoDBStore``, ``InMemoryStore``, ``FilesystemStore``) live in
+``hyperion.adapters.keyval.*``.
 """
 
 import gzip
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator
 from fnmatch import fnmatch
-from typing import Literal, cast
+from typing import Literal, TypeGuard, cast
 
 import snappy
 
 CompressionType = Literal["snappy", "gzip"]
+
+
+def is_valid_compression_type(compression_type: str) -> TypeGuard[CompressionType]:
+    return compression_type in ("snappy", "gzip")
 
 
 class KeyValueStore(ABC, Iterable[str]):

--- a/hyperion/ports/queue.py
+++ b/hyperion/ports/queue.py
@@ -1,9 +1,9 @@
 """Port: message queue abstraction.
 
-Abstract :class:`Queue` base. Message models and concrete adapters
-(``InMemoryQueue``, ``SQSQueue``, ``FileQueue``) live in
-``hyperion.infrastructure.message_queue`` until step S6; the ``from_config``
-family reaches the concrete adapters via a deferred import.
+Abstract :class:`Queue` base. Message models live in
+:mod:`hyperion.domain.messages`; concrete adapters (``InMemoryQueue``,
+``SQSQueue``, ``FileQueue``) live in ``hyperion.adapters.queue.*``. The
+``from_config`` family reaches the concrete adapters via a deferred import.
 """
 
 from __future__ import annotations
@@ -17,7 +17,7 @@ from hyperion.config import queue_config
 from hyperion.log import get_logger
 
 if TYPE_CHECKING:
-    from hyperion.infrastructure.message_queue import Message
+    from hyperion.domain.messages import Message
 
 logger = get_logger("hyperion-queue")
 
@@ -27,7 +27,9 @@ class Queue(abc.ABC):
 
     @staticmethod
     def _resolve_type_from_config() -> type[Queue]:
-        from hyperion.infrastructure.message_queue import FileQueue, InMemoryQueue, SQSQueue
+        from hyperion.adapters.queue.filesystem import FileQueue
+        from hyperion.adapters.queue.memory import InMemoryQueue
+        from hyperion.adapters.queue.sqs import SQSQueue
 
         if queue_config.url and queue_config.path:
             logger.warning(
@@ -43,7 +45,9 @@ class Queue(abc.ABC):
 
     @classmethod
     def _create_from_config(cls) -> Queue:
-        from hyperion.infrastructure.message_queue import FileQueue, InMemoryQueue, SQSQueue
+        from hyperion.adapters.queue.filesystem import FileQueue
+        from hyperion.adapters.queue.memory import InMemoryQueue
+        from hyperion.adapters.queue.sqs import SQSQueue
 
         queue_type = cls._resolve_type_from_config()
         logger.info(

--- a/hyperion/ports/schema_registry.py
+++ b/hyperion/ports/schema_registry.py
@@ -1,7 +1,7 @@
 """Port: schema store abstraction.
 
 Abstract :class:`SchemaStore` base. Concrete adapters (``LocalSchemaStore``,
-``S3SchemaStore``) live in ``hyperion.catalog.schema`` until step S6;
+``S3SchemaStore``) live in ``hyperion.adapters.schema_registry.*``;
 ``_create_new`` reaches them via a deferred import. ``AssetProtocol`` /
 ``AssetType`` are referenced only in annotations, so this port stays free of
 the pandera/polars data stack.
@@ -64,7 +64,8 @@ class SchemaStore(abc.ABC):
 
     @staticmethod
     def _create_new(path: str) -> SchemaStore:
-        from hyperion.catalog.schema import LocalSchemaStore, S3SchemaStore
+        from hyperion.adapters.schema_registry.local import LocalSchemaStore
+        from hyperion.adapters.schema_registry.s3 import S3SchemaStore
 
         parsed = urlparse(path)
         if parsed.scheme == "file" or not parsed.scheme:

--- a/hyperion/ports/secrets.py
+++ b/hyperion/ports/secrets.py
@@ -2,8 +2,9 @@
 
 Abstract :class:`SecretsManager` base and the :data:`SECRET_PATTERN` used by
 ``translate_env_vars``. Concrete adapters (``DummySecretsManager``,
-``AWSSecretsManager``) live in ``hyperion.infrastructure.secretsmanager`` until
-step S6; ``_create_new`` reaches them via a deferred import.
+``AWSSecretsManager``, ``EnvSecretsManager``) live in
+``hyperion.adapters.secrets.*``; ``_create_new`` reaches them via a deferred
+import.
 """
 
 import abc
@@ -22,8 +23,9 @@ class SecretsManager(abc.ABC):
 
     @staticmethod
     def _create_new() -> "SecretsManager":
+        from hyperion.adapters.secrets.aws_sm import AWSSecretsManager
+        from hyperion.adapters.secrets.dummy import DummySecretsManager
         from hyperion.config import secrets_config
-        from hyperion.infrastructure.secretsmanager import AWSSecretsManager, DummySecretsManager
 
         if secrets_config.backend is None:
             logger.warning("No secrets backend is configured. Using dummy secrets manager.")

--- a/hyperion/sources/base.py
+++ b/hyperion/sources/base.py
@@ -10,16 +10,13 @@ from typing import Any, ClassVar, TypeAlias, cast
 from aws_lambda_typing.context import Context
 from aws_lambda_typing.events import EventBridgeEvent, SQSEvent
 
+from hyperion.adapters.queue.filesystem import FileQueue
+from hyperion.adapters.queue.sqs import SQSQueue
 from hyperion.asyncutils import AsyncTaskQueue, get_loop
 from hyperion.catalog import Catalog
 from hyperion.config import source_config, storage_config
 from hyperion.domain.assets import DataLakeAsset
-from hyperion.infrastructure.message_queue import (
-    FileQueue,
-    SourceBackfillMessage,
-    SQSQueue,
-    iter_messages_from_sqs_event,
-)
+from hyperion.domain.messages import SourceBackfillMessage, iter_messages_from_sqs_event
 from hyperion.log import get_logger
 from hyperion.ports.queue import Queue
 

--- a/hyperion/sources/cli.py
+++ b/hyperion/sources/cli.py
@@ -9,7 +9,7 @@ from aws_lambda_typing.events.sqs import SQSEvent, SQSMessage
 
 from hyperion.config import queue_config
 from hyperion.dateutils import utcnow
-from hyperion.infrastructure.message_queue import SourceBackfillMessage, create_backfill_event
+from hyperion.domain.messages import SourceBackfillMessage, create_backfill_event
 from hyperion.log import get_logger
 from hyperion.sources.base import Source, SourceEventType, SourceParamsType
 from hyperion.typeutils import is_typed_dict_instance

--- a/tests/adapters/keyval/test_filesystem.py
+++ b/tests/adapters/keyval/test_filesystem.py
@@ -1,0 +1,114 @@
+"""Unit tests for the new lite ``FilesystemStore`` keyval adapter.
+
+Mirrors the cross-backend contract of ``tests/infrastructure/test_keyval.py``
+(directory-of-files backing, atomic writes, prefix-stripping iteration).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from hyperion.adapters.keyval.filesystem import FilesystemStore
+from hyperion.ports.keyval import KeyValueStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> KeyValueStore:
+    return FilesystemStore(tmp_path / "kv")
+
+
+def test_creates_root_directory(tmp_path: Path) -> None:
+    root = tmp_path / "nested" / "kv"
+    FilesystemStore(root)
+    assert root.is_dir()
+
+
+def test_rejects_non_directory_root(tmp_path: Path) -> None:
+    file_path = tmp_path / "afile"
+    file_path.write_text("x")
+    with pytest.raises(ValueError, match="is not a directory"):
+        FilesystemStore(file_path)
+
+
+class TestFilesystemStoreContract:
+    def test_set_and_get(self, store: KeyValueStore) -> None:
+        store.set("a", "1")
+        assert store.get("a") == "1"
+
+    def test_get_missing(self, store: KeyValueStore) -> None:
+        assert store.get("nope") is None
+
+    def test_set_overwrites(self, store: KeyValueStore) -> None:
+        store.set("a", "1")
+        store.set("a", "2")
+        assert store.get("a") == "2"
+
+    def test_delete(self, store: KeyValueStore) -> None:
+        store.set("a", "1")
+        store.delete("a")
+        assert store.get("a") is None
+
+    def test_delete_missing_is_noop(self, store: KeyValueStore) -> None:
+        store.delete("never-set")
+
+    def test_contains_operator(self, store: KeyValueStore) -> None:
+        store.set("a", "1")
+        assert "a" in store
+        assert "b" not in store
+
+    def test_getitem_setitem_delitem(self, store: KeyValueStore) -> None:
+        store["a"] = "1"
+        assert store["a"] == "1"
+        del store["a"]
+        assert "a" not in store
+
+    def test_keys_fnmatch_glob(self, store: KeyValueStore) -> None:
+        store.set("alpha", "x")
+        store.set("beta", "y")
+        store.set("apple", "z")
+        keys = set(store.keys(match="a*"))
+        assert "alpha" in keys
+        assert "apple" in keys
+        assert "beta" not in keys
+
+    def test_iter_yields_all(self, store: KeyValueStore) -> None:
+        store.set("a", "1")
+        store.set("b", "2")
+        assert {"a", "b"}.issubset(set(iter(store)))
+
+    def test_keys_with_filesystem_unsafe_characters(self, store: KeyValueStore) -> None:
+        # url-safe-base64 filename encoding must round-trip arbitrary keys.
+        key = "ns/sub:weird key"
+        store.set(key, "v")
+        assert store.get(key) == "v"
+        assert key in set(iter(store))
+
+
+def test_prefix_strips_on_iteration(tmp_path: Path) -> None:
+    store = FilesystemStore(tmp_path / "kv", prefix="ns")
+    store.set("a", "ns-value")
+    assert list(iter(store)) == ["a"]
+    assert store.get("a") == "ns-value"
+
+
+def test_prefix_isolates_keyspace(tmp_path: Path) -> None:
+    prefixed = FilesystemStore(tmp_path / "kv", prefix="ns")
+    plain = FilesystemStore(tmp_path / "kv")
+    prefixed.set("a", "ns-value")
+    plain.set("a", "other-value")
+    assert prefixed.get("a") == "ns-value"
+    assert plain.get("a") == "other-value"
+
+
+def test_persists_across_instances(tmp_path: Path) -> None:
+    root = tmp_path / "kv"
+    FilesystemStore(root).set("k", "persisted")
+    assert FilesystemStore(root).get("k") == "persisted"
+
+
+@pytest.mark.parametrize("compression", ["snappy", "gzip", None])
+def test_compression_roundtrip(tmp_path: Path, compression: str | None) -> None:
+    store = FilesystemStore(tmp_path / "kv", compression=compression)  # type: ignore[arg-type]
+    payload = "hello-" * 200
+    store.set("k", payload)
+    assert store.get("k") == payload

--- a/tests/adapters/secrets/test_env.py
+++ b/tests/adapters/secrets/test_env.py
@@ -1,0 +1,25 @@
+"""Unit tests for the new lite ``EnvSecretsManager`` adapter.
+
+Resolves secrets from process environment variables. Not wired into
+``SecretsManager.from_config`` until S8 -- tested directly here.
+"""
+
+import pytest
+
+from hyperion.adapters.secrets.env import EnvSecretsManager
+from hyperion.ports.secrets import SecretsManager
+
+
+def test_is_a_secrets_manager() -> None:
+    assert isinstance(EnvSecretsManager(), SecretsManager)
+
+
+def test_returns_environment_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MY_SECRET", "s3cr3t")  # pragma: allowlist secret
+    assert EnvSecretsManager().get_secret("MY_SECRET") == "s3cr3t"
+
+
+def test_raises_keyerror_for_missing_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ABSENT_SECRET", raising=False)
+    with pytest.raises(KeyError):
+        EnvSecretsManager().get_secret("ABSENT_SECRET")

--- a/tests/catalog/test_schema.py
+++ b/tests/catalog/test_schema.py
@@ -82,7 +82,7 @@ def test_s3_schema_store_lru_cache_avoids_second_call() -> None:
     by counting the number of S3 GETs via a request-counting wrapper around the
     underlying boto3 client.
     """
-    from hyperion.catalog import schema as schema_module
+    from hyperion.adapters.schema_registry import s3 as schema_module
 
     s3 = boto3.client("s3")
     bucket = "schemas-lru-bucket"

--- a/tests/infrastructure/test_httputils.py
+++ b/tests/infrastructure/test_httputils.py
@@ -28,14 +28,14 @@ def test_redact_url(url: str, replace: str, expected: str) -> None:
 
 class TestGetProxyMounts:
     def test_no_proxy(self) -> None:
-        with patch("hyperion.infrastructure.httputils.http_config") as mock_config:
+        with patch("hyperion.adapters.http.proxy.http_config") as mock_config:
             mock_config.proxy_http = None
             mock_config.proxy_https = None
             mounts = get_proxy_mounts()
         assert mounts == {}
 
     def test_http_proxy_only(self) -> None:
-        with patch("hyperion.infrastructure.httputils.http_config") as mock_config:
+        with patch("hyperion.adapters.http.proxy.http_config") as mock_config:
             mock_config.proxy_http = "http://proxy:8080"
             mock_config.proxy_https = None
             mounts = get_proxy_mounts()
@@ -43,7 +43,7 @@ class TestGetProxyMounts:
         assert "https://" in mounts
 
     def test_https_proxy_only(self) -> None:
-        with patch("hyperion.infrastructure.httputils.http_config") as mock_config:
+        with patch("hyperion.adapters.http.proxy.http_config") as mock_config:
             mock_config.proxy_http = None
             mock_config.proxy_https = "http://proxy:8443"
             mounts = get_proxy_mounts()
@@ -51,7 +51,7 @@ class TestGetProxyMounts:
         assert "https://" in mounts
 
     def test_both_proxies(self) -> None:
-        with patch("hyperion.infrastructure.httputils.http_config") as mock_config:
+        with patch("hyperion.adapters.http.proxy.http_config") as mock_config:
             mock_config.proxy_http = "http://proxy:8080"
             mock_config.proxy_https = "http://proxy:8443"
             mounts = get_proxy_mounts()

--- a/tests/test_deprecation_shims.py
+++ b/tests/test_deprecation_shims.py
@@ -1,0 +1,92 @@
+"""S6 backward-compatibility contract.
+
+Every symbol relocated by the ports/adapters split (F7 / Step 6) must stay
+importable from its old path for the whole ``hyperion-sdk`` 1.x line, emit a
+:class:`DeprecationWarning` pointing at the new location, and resolve to the
+*same* object as the new path. ``PersistentCache`` is deliberately excluded --
+it is not relocated in S6 (the ``Catalog`` knot removed in S7).
+"""
+
+import importlib
+
+import pytest
+
+# (old_module, attribute, new_module)
+RELOCATIONS = [
+    # cache: abstracts -> ports, concretes + constants -> adapters
+    ("hyperion.infrastructure.cache", "Cache", "hyperion.ports.cache"),
+    ("hyperion.infrastructure.cache", "CacheStats", "hyperion.ports.cache"),
+    ("hyperion.infrastructure.cache", "CachingError", "hyperion.ports.cache"),
+    ("hyperion.infrastructure.cache", "InMemoryCache", "hyperion.adapters.cache.memory"),
+    ("hyperion.infrastructure.cache", "LocalFileCache", "hyperion.adapters.cache.filesystem"),
+    (
+        "hyperion.infrastructure.cache",
+        "DEFAULT_LOCAL_FILE_CACHE_MAX_SIZE",
+        "hyperion.adapters.cache.filesystem",
+    ),
+    ("hyperion.infrastructure.cache", "DynamoDBCache", "hyperion.adapters.cache.dynamodb"),
+    ("hyperion.infrastructure.cache", "DYNAMODB_MAX_LENGTH", "hyperion.adapters.cache.dynamodb"),
+    # keyval
+    ("hyperion.infrastructure.keyval", "KeyValueStore", "hyperion.ports.keyval"),
+    ("hyperion.infrastructure.keyval", "CompressionType", "hyperion.ports.keyval"),
+    ("hyperion.infrastructure.keyval", "is_valid_compression_type", "hyperion.ports.keyval"),
+    ("hyperion.infrastructure.keyval", "InMemoryStore", "hyperion.adapters.keyval.memory"),
+    ("hyperion.infrastructure.keyval", "DynamoDBStore", "hyperion.adapters.keyval.dynamodb"),
+    # message_queue: abstract -> ports, models -> domain, adapters -> adapters
+    ("hyperion.infrastructure.message_queue", "Queue", "hyperion.ports.queue"),
+    ("hyperion.infrastructure.message_queue", "Message", "hyperion.domain.messages"),
+    ("hyperion.infrastructure.message_queue", "ArrivalEvent", "hyperion.domain.messages"),
+    ("hyperion.infrastructure.message_queue", "DataLakeArrivalMessage", "hyperion.domain.messages"),
+    ("hyperion.infrastructure.message_queue", "SourceBackfillMessage", "hyperion.domain.messages"),
+    ("hyperion.infrastructure.message_queue", "SerializedMessage", "hyperion.domain.messages"),
+    (
+        "hyperion.infrastructure.message_queue",
+        "iter_messages_from_sqs_event",
+        "hyperion.domain.messages",
+    ),
+    ("hyperion.infrastructure.message_queue", "create_backfill_event", "hyperion.domain.messages"),
+    ("hyperion.infrastructure.message_queue", "InMemoryQueue", "hyperion.adapters.queue.memory"),
+    ("hyperion.infrastructure.message_queue", "FileQueue", "hyperion.adapters.queue.filesystem"),
+    ("hyperion.infrastructure.message_queue", "SQSQueue", "hyperion.adapters.queue.sqs"),
+    # secrets
+    ("hyperion.infrastructure.secretsmanager", "SecretsManager", "hyperion.ports.secrets"),
+    ("hyperion.infrastructure.secretsmanager", "SECRET_PATTERN", "hyperion.ports.secrets"),
+    ("hyperion.infrastructure.secretsmanager", "DummySecretsManager", "hyperion.adapters.secrets.dummy"),
+    ("hyperion.infrastructure.secretsmanager", "AWSSecretsManager", "hyperion.adapters.secrets.aws_sm"),
+    # http
+    ("hyperion.infrastructure.httputils", "redact_url", "hyperion.adapters.http.proxy"),
+    ("hyperion.infrastructure.httputils", "get_proxy_mounts", "hyperion.adapters.http.proxy"),
+    # schema registry
+    ("hyperion.catalog.schema", "SchemaStore", "hyperion.ports.schema_registry"),
+    ("hyperion.catalog.schema", "AVRO_SCHEMAS_PATH", "hyperion.adapters.schema_registry.local"),
+    ("hyperion.catalog.schema", "LocalSchemaStore", "hyperion.adapters.schema_registry.local"),
+    ("hyperion.catalog.schema", "S3SchemaStore", "hyperion.adapters.schema_registry.s3"),
+]
+
+
+@pytest.mark.parametrize(("old_module", "attr", "new_module"), RELOCATIONS)
+def test_old_path_warns_and_resolves_to_new_object(old_module: str, attr: str, new_module: str) -> None:
+    old_mod = importlib.import_module(old_module)
+    new_obj = getattr(importlib.import_module(new_module), attr)
+
+    with pytest.warns(DeprecationWarning, match=rf"{new_module}\b"):
+        old_obj = getattr(old_mod, attr)
+
+    assert old_obj is new_obj
+
+
+def test_persistent_cache_not_deprecated() -> None:
+    import warnings
+
+    from hyperion.infrastructure import cache
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        assert cache.PersistentCache is cache.PersistentCache
+
+
+def test_unknown_attribute_still_raises_attribute_error() -> None:
+    from hyperion.infrastructure import keyval
+
+    with pytest.raises(AttributeError, match="no attribute 'DoesNotExist'"):
+        keyval.DoesNotExist  # noqa: B018

--- a/tests/test_import_graph.py
+++ b/tests/test_import_graph.py
@@ -171,3 +171,69 @@ def test_lite_storage_adapters_pull_no_heavy_deps(module: str) -> None:
 )
 def test_catalog_namespace_lazy() -> None:
     assert _heavy_pulled_in("hyperion.catalog") == set()
+
+
+# -- S6 (F7) landed: concrete adapters relocated to hyperion.adapters.<port>.*
+#    and the message models to hyperion.domain.messages. The lite adapters and
+#    the domain message module must not drag boto3 / the data stack. (The
+#    ``dynamodb`` / ``sqs`` / ``aws_sm`` / ``s3`` adapters legitimately import
+#    boto3 and are deliberately excluded here.) --
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        "hyperion.domain.messages",
+        "hyperion.adapters.cache",
+        "hyperion.adapters.cache.memory",
+        "hyperion.adapters.cache.filesystem",
+        "hyperion.adapters.keyval.memory",
+        "hyperion.adapters.keyval.filesystem",
+        "hyperion.adapters.queue.memory",
+        "hyperion.adapters.queue.filesystem",
+        "hyperion.adapters.secrets.dummy",
+        "hyperion.adapters.secrets.env",
+        "hyperion.adapters.schema_registry.local",
+        "hyperion.adapters.http.proxy",
+    ],
+)
+def test_s6_lite_adapters_pull_no_heavy_deps(module: str) -> None:
+    # ``snappy`` is deliberately not asserted against: the cache / keyval ports
+    # ``import snappy`` for (de)compression, so any adapter importing those ports
+    # transitively loads it. snappy is ``[snappy]``-gated at the install level
+    # (Step 10), not by this in-env guard -- same carve-out as numpy / haversine.
+    forbidden = (HEAVY_MODULES - {"snappy"}) & _heavy_pulled_in(module)
+    assert forbidden == set(), f"{module} unexpectedly imports {sorted(forbidden)}"
+
+
+# -- S6 deferred-shim guarantee: importing a deprecated old path must not pull
+#    boto3 (the moved concretes are resolved lazily via __getattr__). The pure
+#    infra shims must also not drag the data stack. --
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        "hyperion.infrastructure.keyval",
+        "hyperion.infrastructure.secretsmanager",
+        "hyperion.infrastructure.message_queue",
+        "hyperion.infrastructure.httputils",
+    ],
+)
+def test_pure_shims_pull_no_heavy_deps(module: str) -> None:
+    # snappy rides along via the cache / keyval ports (see note above); the
+    # contract that matters for the deferred shims is "no boto3 / data stack".
+    forbidden = (HEAVY_MODULES - {"snappy"}) & _heavy_pulled_in(module)
+    assert forbidden == set(), f"{module} unexpectedly imports {sorted(forbidden)}"
+
+
+# ``hyperion.infrastructure.cache`` still hosts PersistentCache -> Catalog and
+# ``hyperion.catalog.schema`` touches the eager ``hyperion.catalog`` namespace
+# (-> fastavro), both status quo until S7 / S9 (F8: test_catalog_namespace_lazy
+# is xfail). The S6 contract for these is narrower: the deferred __getattr__
+# must never pull boto3 for the relocated concretes.
+
+
+@pytest.mark.parametrize("module", ["hyperion.infrastructure.cache", "hyperion.catalog.schema"])
+def test_deferred_shims_do_not_pull_boto3(module: str) -> None:
+    assert "boto3" not in _heavy_pulled_in(module)


### PR DESCRIPTION
## Summary

DDD refactor **S6 / F7** (epic #137, plan `docs/ddd-refactor-plan.md` Step 6). Pure structural refactor — **no behaviour change, no new API**.

Relocates every concrete port implementation out of `hyperion/infrastructure/*` into `hyperion/adapters/<port>/<backend>.py`, moves the message models into `hyperion/domain/messages.py`, and turns the old modules into deprecation shims.

### Moved (class bodies byte-identical)
- `adapters/cache/{memory,filesystem,dynamodb}.py` (incl. `DEFAULT_LOCAL_FILE_CACHE_MAX_SIZE`, `DYNAMODB_MAX_LENGTH`)
- `adapters/keyval/{memory,dynamodb}.py`; `is_valid_compression_type` → `ports/keyval.py`
- `adapters/queue/{memory,filesystem,sqs}.py`; message models + SQS helpers → `domain/messages.py`
- `adapters/secrets/{dummy,aws_sm}.py`
- `adapters/schema_registry/{local,s3}.py` (incl. `AVRO_SCHEMAS_PATH`, `_get_schema_from_s3`)
- `adapters/http/proxy.py` (`redact_url`, `get_proxy_mounts`)

### New lite adapters (the layout demands them; with unit tests)
- `adapters/keyval/filesystem.py` — directory-of-files, urlsafe-b64 filenames, atomic `tempfile`+`os.replace`, prefix-stripped iteration
- `adapters/secrets/env.py` — `os.environ`-backed (not wired into `from_config` until S8)

### Shims
Old `infrastructure/{cache,keyval,message_queue,secretsmanager,httputils}.py` + `catalog/schema.py` become deprecation shims: abstracts re-exported eagerly from lite `ports/*`; relocated concretes resolved **lazily via `importlib` in `__getattr__`** so touching a deprecated namespace never re-pulls boto3. `PersistentCache` deliberately stays in `infrastructure/cache.py` (the `Catalog` knot removed in S7/#132). Port `from_config` deferred imports and internal importers (`catalog`, `sources`) repointed to the new locations so the library no longer deprecation-warns itself.

## Backward compatibility
Every old import path still resolves and emits a `DeprecationWarning` pointing at the new location, resolving to the **same object** (asserted in `tests/test_deprecation_shims.py`).

## Tests
- `tests/test_deprecation_shims.py` — old→new identity + warning contract for every relocated symbol
- `tests/adapters/keyval/test_filesystem.py`, `tests/adapters/secrets/test_env.py` — new lite adapters
- `tests/test_import_graph.py` — lite adapters & deferred shims stay boto3-free (`snappy`/`catalog.schema` carve-outs documented; the latter is the pre-existing F8 condition fixed in S9/#134)

Two justified test edits (impl-coupled, not behaviour): `test_httputils.py` patch target → `adapters.http.proxy`; `test_schema.py` → private `_get_schema_from_s3` at its new module (private symbols are not part of the back-compat contract).

## Verification
- `pytest`: 558 passed, 1 xfailed (pre-existing F8/S9 marker), 0 failed
- `ruff`, `mypy --strict`, full `pre-commit`: clean

Closes #131. Part of #137. Conventional subject is non-bumping (`refactor:`) per the epic release strategy — rebase before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)