### PR TITLE
refactor(composition): centralize from_config wiring

### DIFF
--- a/hyperion/catalog/catalog.py
+++ b/hyperion/catalog/catalog.py
@@ -13,7 +13,6 @@ from uuid import uuid4
 
 from hyperion.adapters.serialization.avro import AvroSerializer, AvroStreamWriter
 from hyperion.asyncutils import AsyncTaskQueue, aiter_any
-from hyperion.config import storage_config
 from hyperion.dateutils import (
     TimeResolution,
     TimeResolutionUnit,
@@ -224,21 +223,9 @@ class Catalog:
         the pre-refactor catalog. (Fixes a long-standing bug where the feature
         store used the *data lake* prefix.)
         """
-        from hyperion.adapters.storage.s3 import S3Storage
+        from hyperion import composition
 
-        def _prefix(value: str) -> str:
-            value = value.strip("/")
-            return f"{value}/" if value else ""
-
-        return Catalog(
-            storage={
-                "data_lake": S3Storage(storage_config.data_lake_bucket, _prefix(storage_config.data_lake_prefix)),
-                "feature": S3Storage(storage_config.feature_store_bucket, _prefix(storage_config.feature_store_prefix)),
-                "persistent_store": S3Storage(
-                    storage_config.persistent_store_bucket, _prefix(storage_config.persistent_store_prefix)
-                ),
-            }
-        )
+        return Catalog(storage=composition.default_storage())
 
     @contextmanager
     def _prepare_asset_storage(

--- a/hyperion/composition.py
+++ b/hyperion/composition.py
@@ -1,0 +1,217 @@
+"""Composition root.
+
+This is the **only** module allowed to import from both ``hyperion.ports`` and
+``hyperion.adapters`` and to construct concrete adapters from environment
+configuration (DDD refactor F9 / Step 8, ``docs/ddd-refactor-plan.md`` layering
+rule 6). Every other module depends on the abstract ports only; the
+``*.from_config`` classmethods on the port classes delegate here so backend
+selection lives in exactly one place.
+
+Selection is config-driven and the chosen adapter is imported *inside* its
+branch -- so a lite install (no ``[aws]`` extra) whose config selects a
+memory/filesystem backend never imports ``boto3``. These functions are pure
+constructors: they do **not** cache. Singleton / instance reuse stays on the
+port wrappers (``Cache._instances``, ``Queue._cached_instance``,
+``SecretsManager._instance``, ``SchemaStore._instances``) so observable
+behaviour is unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+from hyperion.config import geo_config, queue_config, secrets_config, storage_config
+from hyperion.log import get_logger
+
+if TYPE_CHECKING:
+    from hyperion.domain.assets import AssetType
+    from hyperion.ports.cache import Cache
+    from hyperion.ports.geocoder import Geocoder
+    from hyperion.ports.keyval import KeyValueStore
+    from hyperion.ports.queue import Queue
+    from hyperion.ports.schema_registry import SchemaStore
+    from hyperion.ports.secrets import SecretsManager
+    from hyperion.ports.storage import StoragePort
+
+logger = get_logger("composition")
+
+# Queue backend name resolution -- intentionally importing no adapter so the
+# Queue config-consistency check (which runs on every ``Queue.from_config``)
+# stays boto3-free.
+QUEUE_BACKEND_CLASS_NAMES = {
+    "sqs": "SQSQueue",
+    "file": "FileQueue",
+    "memory": "InMemoryQueue",
+}
+
+
+def resolve_queue_backend() -> str:
+    """Resolve the queue backend key (``"sqs"`` | ``"file"`` | ``"memory"``).
+
+    Mirrors the pre-refactor ``Queue._resolve_type_from_config`` 1:1, including
+    the both-URL-and-path ambiguity warning, *without importing any adapter*.
+    """
+    if queue_config.url and queue_config.path:
+        logger.warning(
+            "Ambiguous configuration detected - both queue URL and queue path were set. "
+            "Will default to SQS queue.",
+            queue_url=queue_config.url,
+            queue_path=queue_config.path,
+        )
+    if queue_config.url is not None:
+        return "sqs"
+    if queue_config.path is not None:
+        return "file"
+    return "memory"
+
+
+def default_cache() -> Cache:
+    """Construct the cache adapter selected by configuration."""
+    if storage_config.cache_dynamodb_table:
+        from hyperion.adapters.cache.dynamodb import DynamoDBCache
+
+        logger.info("Using DynamoDB Cache.")
+        return DynamoDBCache(
+            prefix=storage_config.cache_key_prefix,
+            default_ttl=storage_config.cache_dynamodb_default_ttl,
+            table_name=storage_config.cache_dynamodb_table,
+        )
+    if storage_config.cache_local_path:
+        from hyperion.adapters.cache.filesystem import LocalFileCache
+
+        logger.info("Using LocalFileCache.", path=storage_config.cache_local_path)
+        return LocalFileCache(
+            prefix=storage_config.cache_key_prefix,
+            root_path=Path(storage_config.cache_local_path),
+        )
+    from hyperion.adapters.cache.memory import InMemoryCache
+
+    logger.info("Using InMemory Cache.")
+    return InMemoryCache(
+        prefix=storage_config.cache_key_prefix,
+        default_ttl=storage_config.cache_dynamodb_default_ttl,
+    )
+
+
+def default_queue() -> Queue:
+    """Construct the queue adapter selected by configuration."""
+    backend = resolve_queue_backend()
+    logger.info("Resolved queue type from configuration.", queue_backend=backend)
+    if backend == "sqs" and queue_config.url is not None:
+        from hyperion.adapters.queue.sqs import SQSQueue
+
+        logger.info("Using SQS queue.")
+        return SQSQueue(queue_config.url)
+    if backend == "file" and queue_config.path is not None:
+        from hyperion.adapters.queue.filesystem import FileQueue
+
+        logger.info("Using FileQueue.")
+        return FileQueue(Path(queue_config.path), overwrite=queue_config.path_overwrite)
+    if backend == "memory":
+        from hyperion.adapters.queue.memory import InMemoryQueue
+
+        logger.info("Using in-memory queue.")
+        return InMemoryQueue()
+    # Unreachable: resolve_queue_backend only returns sqs/file/memory and the
+    # url/path guards above hold by construction. Kept as a defensive mirror of
+    # the pre-refactor Queue._create_from_config final raise.
+    raise ValueError(  # pragma: no cover
+        f"Unknown queue backend {backend!r} or missing configuration options."
+    )
+
+
+def default_secrets() -> SecretsManager:
+    """Construct the secrets-manager adapter selected by configuration."""
+    if secrets_config.backend is None:
+        from hyperion.adapters.secrets.dummy import DummySecretsManager
+
+        logger.warning("No secrets backend is configured. Using dummy secrets manager.")
+        return DummySecretsManager()
+    if secrets_config.backend == "AWSSecretsManager":
+        from hyperion.adapters.secrets.aws_sm import AWSSecretsManager
+
+        logger.info("Using AWS Secrets Manager.")
+        return AWSSecretsManager()
+    raise ValueError(f"Unsupported secrets backend: {secrets_config.backend!r}.")
+
+
+def default_schema_registry(path: str | None = None) -> SchemaStore:
+    """Construct the schema-store adapter for ``path`` (or the configured one).
+
+    Scheme dispatch is identical to the pre-refactor
+    ``SchemaStore._create_new``: ``file://`` / no scheme -> ``LocalSchemaStore``,
+    ``s3://`` -> ``S3SchemaStore``.
+    """
+    resolved_path = path if path is not None else storage_config.schema_path
+    parsed = urlparse(resolved_path)
+    if parsed.scheme == "file" or not parsed.scheme:
+        from hyperion.adapters.schema_registry.local import LocalSchemaStore
+
+        resolved = (Path(parsed.netloc or "/") / parsed.path.lstrip("/")).resolve()
+        logger.info("Using file schema store.", path=resolved.as_posix())
+        return LocalSchemaStore(resolved)
+    if parsed.scheme == "s3":
+        from hyperion.adapters.schema_registry.s3 import S3SchemaStore
+
+        bucket = parsed.netloc
+        prefix = parsed.path.lstrip("/")
+        logger.info("Using S3 schema store.", bucket=bucket, prefix=prefix)
+        return S3SchemaStore(bucket, prefix)
+    logger.critical("Unsupported schema store scheme.", scheme=parsed.scheme, path=resolved_path)
+    raise ValueError(f"Unsupported schema store scheme {parsed.scheme!r}.")
+
+
+def default_storage() -> dict[AssetType, StoragePort]:
+    """Per-asset-type storage map for ``Catalog.from_config``.
+
+    One :class:`~hyperion.adapters.storage.s3.S3Storage` per asset type, so the
+    on-S3 key layout (bucket + prefix per store) is identical to the
+    pre-refactor catalog. Storage is always S3 today (no memory/filesystem
+    fallback in ``from_config`` -- unchanged behaviour).
+    """
+    from hyperion.adapters.storage.s3 import S3Storage
+
+    def _prefix(value: str) -> str:
+        value = value.strip("/")
+        return f"{value}/" if value else ""
+
+    return {
+        "data_lake": S3Storage(storage_config.data_lake_bucket, _prefix(storage_config.data_lake_prefix)),
+        "feature": S3Storage(storage_config.feature_store_bucket, _prefix(storage_config.feature_store_prefix)),
+        "persistent_store": S3Storage(
+            storage_config.persistent_store_bucket, _prefix(storage_config.persistent_store_prefix)
+        ),
+    }
+
+
+def default_keyval() -> KeyValueStore:
+    """Construct the default key-value store.
+
+    No keyval configuration exists today and Step 8 adds none (no new config
+    keys, no behaviour change). This mirrors ``GoogleMaps.__init__``'s current
+    implicit default. Future config-driven backend selection slots in here
+    without touching call sites.
+    """
+    from hyperion.adapters.keyval.memory import InMemoryStore
+
+    return InMemoryStore()
+
+
+def default_geocoder() -> Geocoder:
+    """Construct the geocoder adapter selected by configuration.
+
+    The composition-root entry point for the geocoder. Behaviourally identical
+    to ``GoogleMaps.from_config`` (fresh instance, no singleton, same missing-key
+    ``ValueError``); the geocode cache uses :func:`default_keyval`, functionally
+    identical to the adapter's implicit ``InMemoryStore`` default. The adapter's
+    own ``GoogleMaps.from_config`` is intentionally left self-contained -- per
+    layering rule 6 an adapter must not import this composition module -- so it
+    does not route through here.
+    """
+    if geo_config.gmaps_api_key is None:
+        raise ValueError("Google Maps API key is not set.")
+    from hyperion.adapters.geocoder.google import GoogleMaps
+
+    return GoogleMaps(api_key=geo_config.gmaps_api_key, keyval=default_keyval())

--- a/hyperion/ports/cache.py
+++ b/hyperion/ports/cache.py
@@ -3,8 +3,9 @@
 Abstract :class:`Cache` base plus its contract types (:class:`CacheStats`,
 :class:`CachingError`). Concrete adapters (``InMemoryCache``, ``LocalFileCache``,
 ``DynamoDBCache``) live in ``hyperion.adapters.cache.*``; ``Cache.from_config``
-reaches them via a deferred import. The deprecated ``PersistentCache`` (the
-``Catalog`` knot, S7) moved to :mod:`hyperion.application.persistent_cache`.
+delegates backend selection to :mod:`hyperion.composition` (the single
+composition root). The deprecated ``PersistentCache`` (the ``Catalog`` knot,
+S7) moved to :mod:`hyperion.application.persistent_cache`.
 """
 
 import hashlib
@@ -13,7 +14,6 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, replace
 from io import BytesIO, StringIO
-from pathlib import Path
 from typing import IO, Any, ClassVar, Literal, cast, overload
 
 import snappy
@@ -76,29 +76,11 @@ class Cache(ABC):
         Returns:
             Cache: A cache instance.
         """
-        from hyperion.adapters.cache.dynamodb import DynamoDBCache
-        from hyperion.adapters.cache.filesystem import LocalFileCache
-        from hyperion.adapters.cache.memory import InMemoryCache
+        from hyperion import composition
 
         instance_key = (storage_config.cache_key_prefix, True)
         if instance_key not in Cache._instances:
-            if storage_config.cache_dynamodb_table:
-                logger.info("Using DynamoDB Cache.")
-                cls._instances[instance_key] = DynamoDBCache(
-                    prefix=storage_config.cache_key_prefix,
-                    default_ttl=storage_config.cache_dynamodb_default_ttl,
-                    table_name=storage_config.cache_dynamodb_table,
-                )
-            elif storage_config.cache_local_path:
-                logger.info("Using LocalFileCache.", path=storage_config.cache_local_path)
-                cls._instances[instance_key] = LocalFileCache(
-                    prefix=storage_config.cache_key_prefix, root_path=Path(storage_config.cache_local_path)
-                )
-            else:
-                logger.info("Using InMemory Cache.")
-                cls._instances[instance_key] = InMemoryCache(
-                    prefix=storage_config.cache_key_prefix, default_ttl=storage_config.cache_dynamodb_default_ttl
-                )
+            cls._instances[instance_key] = composition.default_cache()
         return cls._instances[instance_key]
 
     def __init__(self, prefix: str, hash_keys: bool = True, default_ttl: int = DEFAULT_TTL_SECONDS):

--- a/hyperion/ports/queue.py
+++ b/hyperion/ports/queue.py
@@ -3,77 +3,39 @@
 Abstract :class:`Queue` base. Message models live in
 :mod:`hyperion.domain.messages`; concrete adapters (``InMemoryQueue``,
 ``SQSQueue``, ``FileQueue``) live in ``hyperion.adapters.queue.*``. The
-``from_config`` family reaches the concrete adapters via a deferred import.
+``from_config`` family delegates backend selection to
+:mod:`hyperion.composition` (the single composition root).
 """
 
 from __future__ import annotations
 
 import abc
-import os
-from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
-
-from hyperion.config import queue_config
-from hyperion.log import get_logger
 
 if TYPE_CHECKING:
     from hyperion.domain.messages import Message
-
-logger = get_logger("hyperion-queue")
 
 
 class Queue(abc.ABC):
     _cached_instance: ClassVar[Queue | None] = None
 
-    @staticmethod
-    def _resolve_type_from_config() -> type[Queue]:
-        from hyperion.adapters.queue.filesystem import FileQueue
-        from hyperion.adapters.queue.memory import InMemoryQueue
-        from hyperion.adapters.queue.sqs import SQSQueue
-
-        if queue_config.url and queue_config.path:
-            logger.warning(
-                "Ambiguous configuration detected - both queue URL and queue path were set. Will default to SQS queue.",
-                queue_url=queue_config.url,
-                queue_path=queue_config.path,
-            )
-        if queue_config.url is not None:
-            return SQSQueue
-        if queue_config.path is not None:
-            return FileQueue
-        return InMemoryQueue
-
     @classmethod
     def _create_from_config(cls) -> Queue:
-        from hyperion.adapters.queue.filesystem import FileQueue
-        from hyperion.adapters.queue.memory import InMemoryQueue
-        from hyperion.adapters.queue.sqs import SQSQueue
+        from hyperion import composition
 
-        queue_type = cls._resolve_type_from_config()
-        logger.info(
-            "Resolved queue type from configuration.",
-            queue_type=queue_type,
-            env={k: v for k, v in os.environ.items() if k.lower().startswith("hyperion")},
-        )
-        if queue_type is SQSQueue and queue_config.url is not None:
-            logger.info("Using SQS queue.")
-            return SQSQueue(queue_config.url)
-        if queue_type is FileQueue and queue_config.path is not None:
-            logger.info("Using FileQueue.")
-            return FileQueue(Path(queue_config.path), overwrite=queue_config.path_overwrite)
-        if queue_type is InMemoryQueue:
-            logger.info("Using in-memory queue.")
-            return InMemoryQueue()
-        raise ValueError(f"Unknown queue type {queue_type!r} or missing configuration options.")
+        return composition.default_queue()
 
     @classmethod
     def from_config(cls) -> Queue:
+        from hyperion import composition
+
         if cls._cached_instance is None:
             cls._cached_instance = cls._create_from_config()
-        if cls._cached_instance.__class__ is not (resolved_type := cls._resolve_type_from_config()):
+        expected_class_name = composition.QUEUE_BACKEND_CLASS_NAMES[composition.resolve_queue_backend()]
+        if cls._cached_instance.__class__.__name__ != expected_class_name:
             raise RuntimeError(
                 f"Configuration inconsistency - cached queue instance is of type {type(cls._cached_instance)!r}, "
-                f"but type requested by configuration is {resolved_type!r}."
+                f"but type requested by configuration is {expected_class_name!r}."
             )
         return cls._cached_instance
 

--- a/hyperion/ports/schema_registry.py
+++ b/hyperion/ports/schema_registry.py
@@ -2,25 +2,21 @@
 
 Abstract :class:`SchemaStore` base. Concrete adapters (``LocalSchemaStore``,
 ``S3SchemaStore``) live in ``hyperion.adapters.schema_registry.*``;
-``_create_new`` reaches them via a deferred import. ``AssetProtocol`` /
-``AssetType`` are referenced only in annotations, so this port stays free of
-the pandera/polars data stack.
+``_create_new`` delegates backend selection to :mod:`hyperion.composition`
+(the single composition root). ``AssetProtocol`` / ``AssetType`` are
+referenced only in annotations, so this port stays free of the pandera/polars
+data stack.
 """
 
 from __future__ import annotations
 
 import abc
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
-from urllib.parse import urlparse
 
 from hyperion.config import storage_config
-from hyperion.log import get_logger
 
 if TYPE_CHECKING:
     from hyperion.domain.assets import AssetProtocol, AssetType
-
-logger = get_logger("schema-store")
 
 
 class SchemaStore(abc.ABC):
@@ -64,21 +60,9 @@ class SchemaStore(abc.ABC):
 
     @staticmethod
     def _create_new(path: str) -> SchemaStore:
-        from hyperion.adapters.schema_registry.local import LocalSchemaStore
-        from hyperion.adapters.schema_registry.s3 import S3SchemaStore
+        from hyperion import composition
 
-        parsed = urlparse(path)
-        if parsed.scheme == "file" or not parsed.scheme:
-            resolved = (Path(parsed.netloc or "/") / parsed.path.lstrip("/")).resolve()
-            logger.info("Using file schema store.", path=resolved.as_posix())
-            return LocalSchemaStore(resolved)
-        if parsed.scheme == "s3":
-            bucket = parsed.netloc
-            prefix = parsed.path.lstrip("/")
-            logger.info("Using S3 schema store.", bucket=bucket, prefix=prefix)
-            return S3SchemaStore(bucket, prefix)
-        logger.critical("Unsupported schema store scheme.", scheme=parsed.scheme, path=storage_config.schema_path)
-        raise ValueError(f"Unsupported schema store scheme {parsed.scheme!r}.")
+        return composition.default_schema_registry(path)
 
     @staticmethod
     def from_path(path: str) -> SchemaStore:

--- a/hyperion/ports/secrets.py
+++ b/hyperion/ports/secrets.py
@@ -3,8 +3,8 @@
 Abstract :class:`SecretsManager` base and the :data:`SECRET_PATTERN` used by
 ``translate_env_vars``. Concrete adapters (``DummySecretsManager``,
 ``AWSSecretsManager``, ``EnvSecretsManager``) live in
-``hyperion.adapters.secrets.*``; ``_create_new`` reaches them via a deferred
-import.
+``hyperion.adapters.secrets.*``; ``_create_new`` delegates backend selection to
+:mod:`hyperion.composition` (the single composition root).
 """
 
 import abc
@@ -23,17 +23,9 @@ class SecretsManager(abc.ABC):
 
     @staticmethod
     def _create_new() -> "SecretsManager":
-        from hyperion.adapters.secrets.aws_sm import AWSSecretsManager
-        from hyperion.adapters.secrets.dummy import DummySecretsManager
-        from hyperion.config import secrets_config
+        from hyperion import composition
 
-        if secrets_config.backend is None:
-            logger.warning("No secrets backend is configured. Using dummy secrets manager.")
-            return DummySecretsManager()
-        if secrets_config.backend == "AWSSecretsManager":
-            logger.info("Using AWS Secrets Manager.")
-            return AWSSecretsManager()
-        raise ValueError(f"Unsupported secrets backend: {secrets_config.backend!r}.")
+        return composition.default_secrets()
 
     @staticmethod
     def from_config() -> "SecretsManager":

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -345,7 +345,11 @@ def test_from_config_uses_correct_per_store_prefixes(monkeypatch: pytest.MonkeyP
         feature_store_prefix="fs",
         persistent_store_prefix="ps",
     )
-    monkeypatch.setattr("hyperion.catalog.catalog.storage_config", fake_config)
+    # S8: Catalog.from_config() now delegates storage construction to the
+    # composition root, so the storage_config the buckets/prefixes are read
+    # from lives in hyperion.composition (single shared config.py instance --
+    # production behaviour is unchanged).
+    monkeypatch.setattr("hyperion.composition.storage_config", fake_config)
     # from_config() builds a default SchemaStore from env; stub it out so this
     # test stays focused on storage wiring.
     monkeypatch.setattr("hyperion.catalog.catalog.SchemaStore", types.SimpleNamespace(from_config=lambda: object()))

--- a/tests/entities/test_catalog.py
+++ b/tests/entities/test_catalog.py
@@ -145,16 +145,11 @@ class TestFeatureAsset:
             partition_keys={"region": "eu", "asset_class": "energy"},
         )
         path = asset.get_path()
-        assert path == (
-            "foo.1d/asset_class=energy/region=eu/partition_date=2025-01-02T00:00:00+00:00/v1.avro"
-        )
+        assert path == ("foo.1d/asset_class=energy/region=eu/partition_date=2025-01-02T00:00:00+00:00/v1.avro")
 
     def test_get_path_with_prefix(self) -> None:
         asset = FeatureAsset("foo", datetime.datetime(2025, 1, 2, tzinfo=UTC), "1d")
-        assert (
-            asset.get_path("features")
-            == "features/foo.1d/partition_date=2025-01-02T00:00:00+00:00/v1.avro"
-        )
+        assert asset.get_path("features") == "features/foo.1d/partition_date=2025-01-02T00:00:00+00:00/v1.avro"
 
     def test_get_path_higher_version(self) -> None:
         asset = FeatureAsset("foo", datetime.datetime(2025, 1, 2, tzinfo=UTC), "1d", schema_version=4)

--- a/tests/infrastructure/test_message_queue.py
+++ b/tests/infrastructure/test_message_queue.py
@@ -266,9 +266,7 @@ class TestQueueFromConfig:
         second = Queue.from_config()
         assert first is second
 
-    def test_cached_inconsistent_with_config_raises(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
+    def test_cached_inconsistent_with_config_raises(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         # First call resolves to InMemoryQueue.
         first = Queue.from_config()
         assert isinstance(first, InMemoryQueue)
@@ -301,9 +299,7 @@ class TestSQSEventHelpers:
             list(iter_messages_from_sqs_event(not_an_event))
 
     def test_create_backfill_event_roundtrip(self) -> None:
-        message = SourceBackfillMessage(
-            source="my-source", start_date=datetime.datetime(2025, 1, 1, tzinfo=UTC)
-        )
+        message = SourceBackfillMessage(source="my-source", start_date=datetime.datetime(2025, 1, 1, tzinfo=UTC))
         event = create_backfill_event(message, message_id="m-id", receipt_handle="r-id")
         assert event["Records"][0]["messageAttributes"]["MessageType"]["stringValue"] == "SourceBackfillMessage"
         restored = list(iter_messages_from_sqs_event(event))

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1,0 +1,107 @@
+"""Direct unit coverage for the composition root.
+
+The lite branches (memory cache/queue, dummy secrets, local schema, S3
+storage) are already exercised through the delegating ``*.from_config``
+wrappers (test_message_queue / test_secretsmanager / test_catalog). These
+tests pin the remaining branches -- backend *selection* -- without standing up
+moto: every adapter constructor reached here is lazy (``boto3.resource`` makes
+no network call), so swapping the config object is enough.
+"""
+
+import types
+
+import pytest
+
+from hyperion import composition
+from hyperion.adapters.cache.dynamodb import DynamoDBCache
+from hyperion.adapters.cache.filesystem import LocalFileCache
+from hyperion.adapters.cache.memory import InMemoryCache
+from hyperion.adapters.geocoder.google import GoogleMaps
+from hyperion.adapters.keyval.memory import InMemoryStore
+from hyperion.config import queue_config
+
+
+class TestResolveQueueBackend:
+    """``resolve_queue_backend`` imports no adapter -- pure config dispatch."""
+
+    def test_memory_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(queue_config, "url", None)
+        monkeypatch.setattr(queue_config, "path", None)
+        assert composition.resolve_queue_backend() == "memory"
+
+    def test_sqs_when_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(queue_config, "url", "https://sqs.eu-west-1.amazonaws.com/123/q")
+        monkeypatch.setattr(queue_config, "path", None)
+        assert composition.resolve_queue_backend() == "sqs"
+
+    def test_file_when_path(self, monkeypatch: pytest.MonkeyPatch, tmp_path: object) -> None:
+        monkeypatch.setattr(queue_config, "url", None)
+        monkeypatch.setattr(queue_config, "path", f"{tmp_path}/queue.jsonl")
+        assert composition.resolve_queue_backend() == "file"
+
+    def test_ambiguous_url_and_path_warns_and_picks_sqs(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: object
+    ) -> None:
+        # Exercises the both-set ambiguity warning branch.
+        monkeypatch.setattr(queue_config, "url", "https://sqs.eu-west-1.amazonaws.com/123/q")
+        monkeypatch.setattr(queue_config, "path", f"{tmp_path}/queue.jsonl")
+        assert composition.resolve_queue_backend() == "sqs"
+
+
+class TestDefaultCache:
+    """All three cache backends select the right adapter (1:1 with the old
+    ``Cache.from_config`` body), including the LocalFileCache ``default_ttl``
+    asymmetry."""
+
+    def test_inmemory_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = types.SimpleNamespace(
+            cache_dynamodb_table=None,
+            cache_dynamodb_default_ttl=60,
+            cache_local_path=None,
+            cache_key_prefix="",
+        )
+        monkeypatch.setattr("hyperion.composition.storage_config", fake)
+        assert isinstance(composition.default_cache(), InMemoryCache)
+
+    def test_local_file_when_path_set(self, monkeypatch: pytest.MonkeyPatch, tmp_path: object) -> None:
+        fake = types.SimpleNamespace(
+            cache_dynamodb_table=None,
+            cache_dynamodb_default_ttl=60,
+            cache_local_path=str(tmp_path),
+            cache_key_prefix="",
+        )
+        monkeypatch.setattr("hyperion.composition.storage_config", fake)
+        assert isinstance(composition.default_cache(), LocalFileCache)
+
+    def test_dynamodb_when_table_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = types.SimpleNamespace(
+            cache_dynamodb_table="my-cache-table",
+            cache_dynamodb_default_ttl=120,
+            cache_local_path=None,
+            cache_key_prefix="prefix",
+        )
+        monkeypatch.setattr("hyperion.composition.storage_config", fake)
+        cache = composition.default_cache()
+        assert isinstance(cache, DynamoDBCache)
+        assert cache.table_name == "my-cache-table"
+
+
+def test_default_keyval_is_inmemory() -> None:
+    assert isinstance(composition.default_keyval(), InMemoryStore)
+
+
+class TestDefaultGeocoder:
+    def test_raises_without_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("hyperion.composition.geo_config", types.SimpleNamespace(gmaps_api_key=None))
+        with pytest.raises(ValueError, match="Google Maps API key is not set"):
+            composition.default_geocoder()
+
+    def test_builds_googlemaps_with_inmemory_keyval(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # googlemaps.Client validates key shape (must start with "AIza").
+        monkeypatch.setattr(
+            "hyperion.composition.geo_config",
+            types.SimpleNamespace(gmaps_api_key="AIzaFakeCompositionTestKey"),  # pragma: allowlist secret
+        )
+        geocoder = composition.default_geocoder()
+        assert isinstance(geocoder, GoogleMaps)
+        assert isinstance(geocoder.keyval, InMemoryStore)

--- a/tests/test_import_graph.py
+++ b/tests/test_import_graph.py
@@ -10,8 +10,11 @@ the step lands, the marker flips to XPASS and CI fails until the marker is remov
 """
 
 import json
+import os
 import subprocess
 import sys
+import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -45,11 +48,54 @@ def _loaded_modules(module_name: str) -> set[str]:
 
 def _heavy_pulled_in(module_name: str) -> set[str]:
     loaded = _loaded_modules(module_name)
+    return _heavy_in(loaded)
+
+
+def _heavy_in(loaded: set[str]) -> set[str]:
     hits: set[str] = set()
     for heavy in HEAVY_MODULES:
         if any(m == heavy or m.startswith(f"{heavy}.") for m in loaded):
             hits.add(heavy)
     return hits
+
+
+# Required-no-default storage fields, so `import hyperion.composition` /
+# `hyperion.config` construct cleanly in a hermetic subprocess even though the
+# lite factories below never read these values.
+_LITE_ENV = {
+    "HYPERION_STORAGE_DATA_LAKE_BUCKET": "dl",
+    "HYPERION_STORAGE_FEATURE_STORE_BUCKET": "fs",
+    "HYPERION_STORAGE_PERSISTENT_STORE_BUCKET": "ps",
+    "HYPERION_STORAGE_SCHEMA_PATH": "file:///tmp/hyperion-s8-schemas",
+}
+
+
+def _modules_after_factory(setup: str, call: str, env: dict[str, str]) -> set[str]:
+    """Fresh interpreter with a hermetic env: run `setup`, run `call`, dump `sys.modules`.
+
+    All inherited ``HYPERION_*`` vars are stripped so backend selection is
+    deterministic regardless of the dev/CI environment; ``_LITE_ENV`` + the
+    per-test ``env`` overrides are the only hyperion config the subprocess sees.
+    """
+    program = f"{setup}\n{call}\nimport sys, json\nprint(json.dumps(list(sys.modules.keys())))\n"
+    subprocess_env = {k: v for k, v in os.environ.items() if not k.startswith("HYPERION_")}
+    subprocess_env.update(_LITE_ENV)
+    subprocess_env.update(env)
+    # Run from an isolated cwd so config.py's load_dotenv(find_dotenv(usecwd=True))
+    # can't re-introduce a repo/ancestor .env that would defeat the env strip.
+    with tempfile.TemporaryDirectory() as isolated_cwd:
+        result = subprocess.run(  # noqa: S603 - trusted args (sys.executable + literal program)
+            [sys.executable, "-c", program],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=subprocess_env,
+            cwd=isolated_cwd,
+        )
+    if result.returncode != 0:
+        pytest.fail(f"factory subprocess failed ({setup!r} / {call!r}): {result.stderr}")
+    last_line = [line for line in result.stdout.strip().splitlines() if line][-1]
+    return set(json.loads(last_line))
 
 
 # -- These modules must remain lite today and forever --
@@ -283,3 +329,73 @@ def test_s7_deprecated_geo_paths_defer_googlemaps(module: str) -> None:
     # __init__ re-exports Location from hyperion.domain.geo -> haversine.
     forbidden = (HEAVY_MODULES - {"numpy"}) & _heavy_pulled_in(module)
     assert forbidden == set(), f"{module} unexpectedly imports {sorted(forbidden)}"
+
+
+# -- S8 (F9) landed: the composition root centralizes from_config wiring and
+#    imports the selected adapter *inside* its config branch. The central
+#    promise of epic #137: calling `.from_config()` on a lite install whose
+#    config selects a memory/filesystem backend must NOT import boto3 (the
+#    AWS-only adapter modules `import boto3` at module level, so the old
+#    "import all backends, then branch" factories crashed lite installs). One
+#    assertion per delegating factory. snappy/numpy ride along legitimately via
+#    the cache/keyval ports + haversine (same carve-out as the S6/S7 guards);
+#    the contract that matters is "no boto3 / botocore / aioboto3 / fastavro". --
+
+_S8_AWS_AND_CATALOG_DEPS = {"boto3", "botocore", "aioboto3", "fastavro"}
+
+
+def test_composition_module_stays_lite() -> None:
+    # Importing the composition root itself must pull nothing heavy -- every
+    # adapter import is deferred inside a config branch.
+    assert _heavy_pulled_in("hyperion.composition") == set()
+
+
+def test_cache_from_config_lite_pulls_no_boto3() -> None:
+    # No HYPERION_STORAGE_CACHE_* -> InMemoryCache.
+    loaded = _modules_after_factory("from hyperion.ports.cache import Cache", "Cache.from_config()", env={})
+    forbidden = _S8_AWS_AND_CATALOG_DEPS & _heavy_in(loaded)
+    assert forbidden == set(), f"Cache.from_config() (lite) pulled {sorted(forbidden)}"
+
+
+def test_queue_from_config_lite_pulls_no_boto3() -> None:
+    # No HYPERION_QUEUE_* -> InMemoryQueue; the config-consistency check must
+    # also not import SQSQueue (it resolves a backend *name*, not a type).
+    loaded = _modules_after_factory("from hyperion.ports.queue import Queue", "Queue.from_config()", env={})
+    forbidden = _S8_AWS_AND_CATALOG_DEPS & _heavy_in(loaded)
+    assert forbidden == set(), f"Queue.from_config() (lite) pulled {sorted(forbidden)}"
+
+
+def test_filequeue_from_config_lite_pulls_no_boto3(tmp_path: Path) -> None:
+    # A non-memory lite backend (FileQueue) still must not pull boto3 -- proves
+    # the consistency check is boto3-free even when a backend is configured.
+    loaded = _modules_after_factory(
+        "from hyperion.ports.queue import Queue",
+        "Queue.from_config()",
+        env={"HYPERION_QUEUE_PATH": f"{tmp_path}/queue.jsonl"},
+    )
+    forbidden = _S8_AWS_AND_CATALOG_DEPS & _heavy_in(loaded)
+    assert forbidden == set(), f"Queue.from_config() (FileQueue) pulled {sorted(forbidden)}"
+
+
+def test_secrets_from_config_lite_pulls_no_boto3() -> None:
+    # No HYPERION_SECRETS_BACKEND -> DummySecretsManager.
+    loaded = _modules_after_factory(
+        "from hyperion.ports.secrets import SecretsManager", "SecretsManager.from_config()", env={}
+    )
+    forbidden = _S8_AWS_AND_CATALOG_DEPS & _heavy_in(loaded)
+    assert forbidden == set(), f"SecretsManager.from_config() (lite) pulled {sorted(forbidden)}"
+
+
+def test_schema_registry_from_config_lite_pulls_no_boto3(tmp_path: Path) -> None:
+    # A file:// schema path -> LocalSchemaStore (the S3SchemaStore branch, which
+    # transitively pulls boto3, must not be imported). LocalSchemaStore validates
+    # the path exists (unchanged behaviour), so create it first.
+    schemas_dir = tmp_path / "schemas"
+    schemas_dir.mkdir()
+    loaded = _modules_after_factory(
+        "from hyperion.ports.schema_registry import SchemaStore",
+        "SchemaStore.from_config()",
+        env={"HYPERION_STORAGE_SCHEMA_PATH": schemas_dir.as_uri()},
+    )
+    forbidden = _S8_AWS_AND_CATALOG_DEPS & _heavy_in(loaded)
+    assert forbidden == set(), f"SchemaStore.from_config() (lite) pulled {sorted(forbidden)}"


### PR DESCRIPTION
## S8 / #133 — composition root (epic #137, `docs/ddd-refactor-plan.md` Step 8, fixes **F9**, layering rule 6)

Pure structural refactor. **No new features/API, no behaviour change, no new config keys.**

### Problem
Every `from_config()` factory imported *all* backends at the top of the method *before* the config branch selected one. The AWS adapter modules (`adapters/*/dynamodb.py`, `sqs.py`, `aws_sm.py`, `schema_registry/s3.py`) `import boto3` at module level, so on a lite install (`pip install hyperion-sdk`, no `[aws]`) whose config selects a memory/filesystem backend, calling `.from_config()` still raised `ImportError: boto3` — breaking epic #137's central promise.

### Change
- New `hyperion/composition.py` — the single composition root, the only module importing from both `ports/` and `adapters/`. Each `default_*()` reads env config and imports **only the selected adapter inside its chosen branch**. Pure constructors (no caching).
- Port `from_config()` methods keep their singleton/cache wrappers (`Cache._instances`, `Queue._cached_instance`, `SecretsManager._instance`, `SchemaStore._instances`) and delegate construction to composition via a deferred `from hyperion import composition`.
- `Queue` config-consistency check now resolves a backend **name** (`resolve_queue_backend()` + `QUEUE_BACKEND_CLASS_NAMES`) instead of importing all 3 queue adapters — it was pulling boto3 via `SQSQueue` on every `from_config()` call. `RuntimeError` semantics preserved (still raised on mismatch; keeps the `"Configuration inconsistency"` prefix).
- `Catalog.from_config()` delegates to `composition.default_storage()` (same 3-store S3 dict + per-store prefix logic).
- Dead imports left by the move removed from the touched modules.

### Behaviour notes
- Selection logic is 1:1 with the pre-refactor factories (same backends, same `ValueError`/warning texts, the cache `default_ttl` asymmetry, the catalog per-store prefix bugfix from S5).
- Only observable change: the `Queue` inconsistency `RuntimeError`'s *expected* side now shows a class-name string (e.g. `'SQSQueue'`) instead of a `<class …>` repr — tests assert the `"Configuration inconsistency"` prefix, unaffected.
- `default_keyval()` → `InMemoryStore()` and `default_geocoder()` mirror today's behaviour exactly. **Persistent-keyval geocode caching is intentionally deferred** (needs a new config key — out of scope for #133; warrants its own issue).
- `GoogleMaps.from_config` is intentionally left self-contained: per layering rule 6 an adapter must not import composition.

### Verification
- Full suite green (py3.13 local): **580 passed, 1 xfailed** (the expected S9 catalog-namespace xfail).
- New hermetic subprocess assertions in `tests/test_import_graph.py`: lite-config `Cache/Queue/SecretsManager/SchemaStore.from_config()` (incl. a FileQueue case) load no `boto3/botocore/aioboto3/fastavro`; `import hyperion.composition` pulls nothing heavy.
- Manual lite-env check (HYPERION_* stripped): all four `.from_config()` succeed with zero heavy modules loaded.
- `ruff` + `mypy` clean on all changed files.

Reviewed by a review agent: APPROVE, no blockers; the two non-blocking nits it raised were applied (docstring clarification + subprocess isolated-cwd hardening).

Closes #133. Part of epic #137. Non-bumping (`refactor:`/`test:`); merge via **Rebase and merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)