### PR TITLE
refactor(catalog): make hyperion.catalog import lazy

### DIFF
--- a/hyperion/application/persistent_cache.py
+++ b/hyperion/application/persistent_cache.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from base64 import b64decode, b64encode
 from typing import Any
 
-from hyperion.catalog import AssetNotFoundError, Catalog
+from hyperion.catalog.catalog import AssetNotFoundError, Catalog
 from hyperion.dateutils import utcnow
 from hyperion.domain.assets import PersistentStoreAsset
 from hyperion.log import get_logger

--- a/hyperion/catalog/__init__.py
+++ b/hyperion/catalog/__init__.py
@@ -1,9 +1,54 @@
-from hyperion.ports.schema_registry import SchemaStore
+"""Deprecated import shim for the ``hyperion.catalog`` namespace.
 
-from .catalog import AssetNotFoundError, Catalog
+.. deprecated::
+    Touching this namespace must not eagerly load ``fastavro``/boto3 (F8 /
+    Step 9). Import the symbols from their explicit modules instead:
+    :class:`Catalog` / :class:`AssetNotFoundError` ->
+    :mod:`hyperion.catalog.catalog`, the abstract :class:`SchemaStore` ->
+    :mod:`hyperion.ports.schema_registry`. This package keeps every symbol
+    importable (with a :class:`DeprecationWarning`, ``Catalog`` /
+    ``AssetNotFoundError`` resolved lazily so ``import hyperion.catalog`` pulls
+    neither ``fastavro`` nor boto3) for the whole ``hyperion-sdk`` 1.x line. The
+    aliases are removed in 2.0.
+"""
+
+import importlib
+from typing import TYPE_CHECKING
+
+from hyperion._compat import moved_attr
+from hyperion.ports.schema_registry import SchemaStore as _SchemaStore
+
+if TYPE_CHECKING:
+    from hyperion.catalog.catalog import AssetNotFoundError, Catalog
+    from hyperion.ports.schema_registry import SchemaStore
+
+_OLD_MODULE = "hyperion.catalog"
+
+# Abstract contract type -- already imported from the lite ``ports`` layer.
+_MOVED: dict[str, tuple[object, str]] = {
+    "SchemaStore": (_SchemaStore, "hyperion.ports.schema_registry"),
+}
+
+# ``Catalog`` + ``AssetNotFoundError`` resolved lazily so importing this
+# namespace never pulls ``fastavro`` (the avro serializer) or boto3.
+_MOVED_LAZY: dict[str, str] = {
+    "Catalog": "hyperion.catalog.catalog",
+    "AssetNotFoundError": "hyperion.catalog.catalog",
+}
 
 __all__ = [
     "AssetNotFoundError",
     "Catalog",
     "SchemaStore",
 ]
+
+
+def __getattr__(name: str) -> object:
+    if name in _MOVED:
+        value, new_module = _MOVED[name]
+        return moved_attr(name=name, value=value, old_module=_OLD_MODULE, new_module=new_module)
+    if name in _MOVED_LAZY:
+        new_module = _MOVED_LAZY[name]
+        module = importlib.import_module(new_module)
+        return moved_attr(name=name, value=getattr(module, name), old_module=_OLD_MODULE, new_module=new_module)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/hyperion/repository/asset_collection.py
+++ b/hyperion/repository/asset_collection.py
@@ -12,7 +12,7 @@ import pandera.typing.polars
 import polars
 
 from hyperion.asyncutils import iter_async
-from hyperion.catalog import Catalog
+from hyperion.catalog.catalog import Catalog
 from hyperion.data.asset_schemas import FeatureModel, PolarsFeatureModel
 from hyperion.dateutils import TimeResolution, utcnow
 from hyperion.domain.assets import FeatureAsset

--- a/hyperion/sources/base.py
+++ b/hyperion/sources/base.py
@@ -13,7 +13,7 @@ from aws_lambda_typing.events import EventBridgeEvent, SQSEvent
 from hyperion.adapters.queue.filesystem import FileQueue
 from hyperion.adapters.queue.sqs import SQSQueue
 from hyperion.asyncutils import AsyncTaskQueue, get_loop
-from hyperion.catalog import Catalog
+from hyperion.catalog.catalog import Catalog
 from hyperion.config import source_config, storage_config
 from hyperion.domain.assets import DataLakeAsset
 from hyperion.domain.messages import SourceBackfillMessage, iter_messages_from_sqs_event

--- a/tests/test_deprecation_shims.py
+++ b/tests/test_deprecation_shims.py
@@ -1,7 +1,8 @@
-"""S6 + S7 backward-compatibility contract.
+"""S6 + S7 + S9 backward-compatibility contract.
 
-Every symbol relocated by the ports/adapters split (F7 / Step 6) and the
-geocoder/PersistentCache inversion (F3 / F4 / Step 7) must stay importable from
+Every symbol relocated by the ports/adapters split (F7 / Step 6), the
+geocoder/PersistentCache inversion (F3 / F4 / Step 7), and the
+``hyperion.catalog`` namespace lazy shim (F8 / Step 9) must stay importable from
 its old path for the whole ``hyperion-sdk`` 1.x line, emit a
 :class:`DeprecationWarning` pointing at the new location, and resolve to the
 *same* object as the new path. ``PersistentCache`` is now relocated (S7) to
@@ -67,6 +68,10 @@ RELOCATIONS = [
     ("hyperion.infrastructure.geo.gmaps", "GoogleMaps", "hyperion.adapters.geocoder.google"),
     ("hyperion.infrastructure.geo", "GoogleMaps", "hyperion.adapters.geocoder.google"),
     ("hyperion.infrastructure.cache", "PersistentCache", "hyperion.application.persistent_cache"),
+    # S9: hyperion.catalog namespace lazy shim
+    ("hyperion.catalog", "Catalog", "hyperion.catalog.catalog"),
+    ("hyperion.catalog", "AssetNotFoundError", "hyperion.catalog.catalog"),
+    ("hyperion.catalog", "SchemaStore", "hyperion.ports.schema_registry"),
 ]
 
 

--- a/tests/test_import_graph.py
+++ b/tests/test_import_graph.py
@@ -207,15 +207,11 @@ def test_lite_storage_adapters_pull_no_heavy_deps(module: str) -> None:
     assert hits == set(), f"{module} unexpectedly imports {sorted(hits)}"
 
 
-# -- This module currently violates the promise; the refactor fixes it --
-# `strict=True` means the marker fails CI as soon as the test starts passing —
-# forcing the marker to be removed when the corresponding refactor step lands.
+# -- S9 (F8) landed: hyperion/catalog/__init__.py is now a lazy two-map shim;
+#    touching the namespace pulls neither fastavro nor boto3 (Catalog /
+#    AssetNotFoundError resolve lazily via __getattr__). --
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Refactor F8 / Step 9: hyperion.catalog namespace must not eagerly load fastavro/boto3.",
-)
 def test_catalog_namespace_lazy() -> None:
     assert _heavy_pulled_in("hyperion.catalog") == set()
 
@@ -278,11 +274,12 @@ def test_pure_shims_pull_no_heavy_deps(module: str) -> None:
     assert forbidden == set(), f"{module} unexpectedly imports {sorted(forbidden)}"
 
 
-# ``hyperion.catalog.schema`` touches the eager ``hyperion.catalog`` namespace
-# (-> fastavro), status quo until S9 (F8: test_catalog_namespace_lazy is xfail).
-# The S6 contract here is narrower: the deferred __getattr__ must never pull
-# boto3 for the relocated concretes. (``hyperion.infrastructure.cache`` graduated
-# to the stricter pure-shim guard above once S7 cut the Catalog knot.)
+# ``hyperion.catalog.schema`` is a deferred shim; the S6 contract asserted here
+# is narrowly that its __getattr__ must never pull boto3 for the relocated
+# concretes. (Since S9 made the ``hyperion.catalog`` namespace lazy, importing
+# this shim no longer drags fastavro either -- the stronger no-heavy guarantee
+# is covered by ``test_catalog_namespace_lazy`` above. ``hyperion.infrastructure
+# .cache`` graduated to the stricter pure-shim guard once S7 cut the Catalog knot.)
 
 
 @pytest.mark.parametrize("module", ["hyperion.catalog.schema"])


### PR DESCRIPTION
Closes #134 — **S9 (F8)** of the DDD refactor epic #137. Pure structural refactor: **no behaviour change, no API additions, no removals**. Non-bumping (`refactor:`).

## Problem
`hyperion/catalog/__init__.py` eagerly did `from .catalog import AssetNotFoundError, Catalog`, and `hyperion/catalog/catalog.py:14` imports `AvroSerializer` → so merely touching the `hyperion.catalog` namespace (even to type-hint `AssetNotFoundError`) pulled **fastavro** (and transitively boto3). This blocked the slim-lite-core goal (S10) and kept `test_catalog_namespace_lazy` `xfail(strict=True)`.

## Change
- **`hyperion/catalog/__init__.py`** → the established two-map PEP 562 `__getattr__` deprecation shim (verbatim with `hyperion/catalog/schema.py` / `hyperion/infrastructure/cache.py`):
  - `_MOVED` (eager): `SchemaStore` from the lite `hyperion.ports.schema_registry`.
  - `_MOVED_LAZY` (deferred via `importlib`): `Catalog`, `AssetNotFoundError` from `hyperion.catalog.catalog` — so the namespace import pulls neither fastavro nor boto3.
  - All three legacy names stay importable for the whole 1.x line, emitting a `DeprecationWarning` pointing at the explicit module; removed in 2.0.
- **Sweep the 3 first-party namespace importers** onto the explicit `hyperion.catalog.catalog` submodule so the package does not deprecation-warn itself: `repository/asset_collection.py`, `sources/base.py`, `application/persistent_cache.py`. (`sources/cli.py` has no catalog import — nothing to do; `application/persistent_cache.py` was an importer the issue text omitted but it is correctly handled here.)
- **Tests**: drop the now-passing `xfail(strict=True)` on `test_catalog_namespace_lazy`; add the 3 catalog rows to the `RELOCATIONS` deprecation-shim contract; refresh two now-stale narrative comments.

## Verification
- `python -X importtime -c "import hyperion.catalog"` → no `fastavro`/`boto3`; `sys.modules` leak check clean.
- `from hyperion.catalog import Catalog, AssetNotFoundError, SchemaStore` still resolves; each emits a `DeprecationWarning` pointing at the new path; old object **is** the new object.
- Full suite: **594 passed**, `test_catalog_namespace_lazy` now passes (no XPASS).
- `pre-commit run -a` green (mypy --strict, ruff). CI runs py3.10–3.14.
- Independently reviewed by a review agent: approved (correct pattern application, no scope creep, no missed importer).

## Merge
"Rebase and merge" only (keeps `cz bump --get-next` accurate). Rebase on `master` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)