### PR TITLE
docs: refresh README + asset_collections for v1.0.0 paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,30 @@ Sources are responsible for extracting data from external systems and storing it
 If you only want to use `hyperion`, you can install it from PyPI:
 
 ```bash
-pip install hyperion-etl
+pip install hyperion-sdk
 # or
-poetry add hyperion-etl
+poetry add hyperion-sdk
 ```
 
-We'll try to respect [Semantic Versioning](https://semver.org/), so you can pin your dependencies to a specific version,
-or use a version selector to make sure no breaking changes are introduced (e.g., `^0.4.0`).
+As of `1.0.0` the default install is a slim **lite core**. Heavy backends are opt-in
+extras — install the ones you use:
+
+| Extra | Enables |
+|---|---|
+| `hyperion-sdk[aws]` | DynamoDB cache/keyval, S3 storage/schema, SQS queue, AWS Secrets Manager |
+| `hyperion-sdk[data]` | pandera↔polars typing, asset schemas, `SpatialKMeans` |
+| `hyperion-sdk[catalog]` | avro-backed `Catalog` (works with local filesystem storage alone) |
+| `hyperion-sdk[geo]` | Google Maps geocoding (Haversine math stays lite) |
+| `hyperion-sdk[snappy]` | snappy-compressed filesystem cache / DynamoDB keyval |
+| `hyperion-sdk[all]` | everything (parity with the pre-1.0 full install) |
+
+For example, the catalog examples below need `pip install 'hyperion-sdk[catalog]'`;
+add `[aws]` as well if you store assets on S3.
+
+We follow [Semantic Versioning](https://semver.org/), so you can pin your dependencies to
+a specific version or use a version selector to avoid breaking changes (e.g., `^1.0.0`).
+**Upgrading from a pre-1.0 release?** Import paths moved and the `Catalog` constructor
+changed — see the migration guide at the top of [`CHANGELOG.md`](./CHANGELOG.md).
 
 ### From Source
 
@@ -165,8 +182,8 @@ Before any real documentation is written, you can check the
 #### Creating and Storing a DataLakeAsset
 
 ```python
-from hyperion.catalog import Catalog
-from hyperion.entities.catalog import DataLakeAsset
+from hyperion.catalog.catalog import Catalog
+from hyperion.domain.assets import DataLakeAsset
 from datetime import datetime, timezone
 
 # Initialize the catalog
@@ -191,8 +208,8 @@ catalog.store_asset(asset, data)
 #### Working with FeatureAssets
 
 ```python
-from hyperion.catalog import Catalog
-from hyperion.entities.catalog import FeatureAsset
+from hyperion.catalog.catalog import Catalog
+from hyperion.domain.assets import FeatureAsset
 from hyperion.dateutils import TimeResolution
 from datetime import datetime, timezone
 
@@ -234,8 +251,8 @@ for feature_asset in catalog.iter_feature_store_partitions(
 #### Working with PersistentStoreAssets
 
 ```python
-from hyperion.catalog import Catalog
-from hyperion.entities.catalog import PersistentStoreAsset
+from hyperion.catalog.catalog import Catalog
+from hyperion.domain.assets import PersistentStoreAsset
 
 # Initialize the catalog
 catalog = Catalog.from_config()
@@ -262,19 +279,23 @@ for product in catalog.retrieve_asset(asset):
 #### Using a Cached Catalog
 
 ```python
-from hyperion.catalog import Catalog
-from hyperion.infrastructure.cache import LocalFileCache
 from pathlib import Path
 
-# Create a catalog with a local file cache
+from hyperion.catalog.catalog import Catalog
+from hyperion.adapters.cache.filesystem import LocalFileCache
+from hyperion.adapters.storage.filesystem import FilesystemStorage
+from hyperion.adapters.schema_registry.local import LocalSchemaStore
+
+# Create a catalog backed by local storage with a local file cache.
+# (Catalog.from_config() instead wires S3 storage from the environment; it does
+# not configure a cache — pass `cache=` explicitly, as shown here, to enable it.)
 cached_catalog = Catalog(
-    data_lake_bucket="my-data-lake-bucket",
-    feature_store_bucket="my-feature-store-bucket",
-    persistent_store_bucket="my-persistent-store-bucket",
-    cache=LocalFileCache("catalog", default_ttl=3600, root_path=Path("/tmp/hyperion-cache"))
+    storage=FilesystemStorage("/data/lake"),
+    schema_store=LocalSchemaStore(Path("/data/schemas")),
+    cache=LocalFileCache("catalog", default_ttl=3600, root_path=Path("/tmp/hyperion-cache")),
 )
 
-# First retrieval will download from S3
+# First retrieval reads from storage
 data = list(cached_catalog.retrieve_asset(asset))
 
 # Subsequent retrievals will use the cache
@@ -288,8 +309,8 @@ import asyncio
 from datetime import datetime, timezone
 from typing import AsyncIterator
 
-from hyperion.catalog import Catalog
-from hyperion.entities.catalog import DataLakeAsset
+from hyperion.catalog.catalog import Catalog
+from hyperion.domain.assets import DataLakeAsset
 from hyperion.sources.base import Source, SourceAsset
 
 
@@ -406,8 +427,8 @@ See [`docs/asset_collections.md`](docs/asset_collections.md) for more informatio
 ### Repartitioning Data
 
 ```python
-from hyperion.catalog import Catalog
-from hyperion.entities.catalog import DataLakeAsset
+from hyperion.catalog.catalog import Catalog
+from hyperion.domain.assets import DataLakeAsset
 from hyperion.dateutils import TimeResolutionUnit
 from datetime import datetime, timezone
 import asyncio
@@ -442,7 +463,7 @@ Hyperion provides two types of caching:
 #### Key-Value Cache
 
 ```python
-from hyperion.infrastructure.cache import Cache
+from hyperion.ports.cache import Cache
 
 # Get cache from configuration
 cache = Cache.from_config()
@@ -465,25 +486,28 @@ cache.delete("my-key")
 #### Catalog Asset Cache
 
 ```python
-from hyperion.catalog import Catalog
-from hyperion.infrastructure.cache import LocalFileCache
+from pathlib import Path
 
-# Create a catalog with a local file cache
+from hyperion.catalog.catalog import Catalog
+from hyperion.adapters.cache.filesystem import LocalFileCache
+from hyperion.adapters.storage.filesystem import FilesystemStorage
+
+# Asset caching requires a cache to be injected into the Catalog.
+# Catalog.from_config() wires storage from the environment but does NOT
+# configure a cache, so pass `cache=` explicitly to enable caching.
 catalog = Catalog(
-    data_lake_bucket="my-data-lake-bucket",
-    feature_store_bucket="my-feature-store-bucket",
-    persistent_store_bucket="my-persistent-store-bucket",
-    cache=LocalFileCache("catalog", root_path="/tmp/hyperion-cache")
+    storage=FilesystemStorage("/data/lake"),
+    cache=LocalFileCache("catalog", root_path=Path("/tmp/hyperion-cache")),
 )
 
 # Now asset retrievals will be cached
-# First time: downloads from S3
+# First time: reads from storage
 data1 = list(catalog.retrieve_asset(asset1))
 
 # Second time: uses cache
 data1_again = list(catalog.retrieve_asset(asset1))  # Much faster!
 
-# Different asset: downloads from S3
+# Different asset: reads from storage
 data2 = list(catalog.retrieve_asset(asset2))
 
 # Force bypass cache for a specific retrieval
@@ -495,7 +519,8 @@ with catalog._get_asset_file_handle(asset, no_cache=True) as file:
 ### Geo Utilities
 
 ```python
-from hyperion.infrastructure.geo import GoogleMaps, Location
+from hyperion.adapters.geocoder.google import GoogleMaps
+from hyperion.domain.geo import Location
 
 # Initialize Google Maps client
 gmaps = GoogleMaps.from_config()

--- a/docs/asset_collections.md
+++ b/docs/asset_collections.md
@@ -20,13 +20,17 @@ You can define feature models using either Pydantic (for object-oriented data) o
 
 #### Option A: Pydantic Model
 
-Create a model class that extends both `FeatureModel` and `pydantic.BaseModel`:
+Create a model class that extends both `FeatureModel` and `pydantic.BaseModel`.
+Feature models live in `hyperion.data`, so this requires the `[data]` extra
+(`pip install 'hyperion-sdk[data]'`):
 
 ```python
-from pydantic import BaseModel
-from hyperion.entities.catalog import FeatureModel
-from hyperion.dateutils import TimeResolution
 import datetime
+from typing import ClassVar
+
+from pydantic import BaseModel
+from hyperion.data.asset_schemas import FeatureModel
+from hyperion.dateutils import TimeResolution
 
 class WeatherFeature(FeatureModel, BaseModel):
     asset_name: ClassVar = "weather_data"
@@ -42,10 +46,11 @@ class WeatherFeature(FeatureModel, BaseModel):
 For large datasets or analytics workloads, create a model using `PolarsFeatureModel`:
 
 ```python
+import polars as pl
 import pandera.typing.polars as pt
 from typing import Annotated, ClassVar
 from pandera.engines.polars_engine import DateTime, Float64
-from hyperion.entities.catalog import PolarsFeatureModel
+from hyperion.data.asset_schemas import PolarsFeatureModel
 from hyperion.dateutils import TimeResolution
 
 class WeatherPolarsFeature(PolarsFeatureModel):


### PR DESCRIPTION
## What

Refresh `README.md` and `docs/asset_collections.md` for the v1.0.0 ports/adapters layout. Documentation-only — no code changes.

## Why

The just-shipped DDD refactor moved 58 symbols and changed the `Catalog` constructor. The docs still showed the wrong PyPI package name and two **outright-broken** `Catalog(*_bucket=...)` constructors, plus several deprecated import paths.

## Changes

- Correct PyPI package name: `hyperion-etl` → `hyperion-sdk`.
- Add a lite-core + extras install table (`[aws] [data] [catalog] [geo] [snappy] [all]`) and a pre-1.0 migration pointer to `CHANGELOG.md`.
- Rewrite both removed `Catalog(data_lake_bucket=..., ...)` constructors using `storage=` (`FilesystemStorage` + `LocalSchemaStore`) and `Catalog.from_config()`.
- Move all example imports to canonical 1.0 paths: `hyperion.catalog.catalog`, `hyperion.domain.assets`, `hyperion.ports.cache`, `hyperion.adapters.cache/storage/schema_registry/geocoder`, `hyperion.domain.geo`, `hyperion.data.asset_schemas`.

## Verification

- Every corrected import block resolves under `python -W error::DeprecationWarning` (zero deprecation warnings in docs examples).
- Constructor signatures cross-checked against the live `Catalog`, `FilesystemStorage`, `LocalSchemaStore`, `LocalFileCache` source.
- `docs/ddd-refactor-plan.md` intentionally left as-is (internal spec documenting the pre-1.0 state).

Part of the v1.0.0 post-release close-out (epic #137).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
