### PR TITLE
docs: Diataxis mkdocs site → GitHub Pages (auto API reference)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,74 @@
+name: docs
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+env:
+  # Silence the mkdocs-material 9.7 promotional "MkDocs 2.0 / ProperDocs"
+  # banner so it does not clutter (or alarm reviewers in) CI logs. The mkdocs
+  # core warning honours DISABLE_MKDOCS_2_WARNING; the mkdocs-material banner
+  # actually checks NO_MKDOCS_2_WARNING (its printed hint names the wrong var).
+  DISABLE_MKDOCS_2_WARNING: "true"
+  NO_MKDOCS_2_WARNING: "true"
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout
+        with:
+          lfs: true
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install poetry
+        run: python -m pip install poetry
+      - name: Install docs dependencies
+        run: poetry install --only docs
+      - name: Build site (strict)
+        run: poetry run mkdocs build --strict --site-dir site
+      - name: Upload Pages artifact
+        if: github.ref == 'refs/heads/master'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+      - name: Upload reviewable site artifact
+        if: github.ref != 'refs/heads/master'
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-site
+          path: site/
+
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+      contents: read
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,11 @@ venv.bak/
 
 # mkdocs documentation
 /site
+# API reference is generated into the build tree by mkdocs-gen-files; guard
+# the source tree against a stray standalone run of docs/gen_ref_pages.py.
+/docs/reference/**
+!/docs/reference/
+!/docs/reference/migration-pre-1.0.md
 
 # mypy
 .mypy_cache/

--- a/README.md
+++ b/README.md
@@ -9,94 +9,36 @@ A headless ETL / ELT / data pipeline and integration SDK for Python.
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/hyperion-sdk)
 ![GitHub Release](https://img.shields.io/github/v/release/tomasvotava/hyperion)
 
+📚 **Documentation: <https://tomasvotava.github.io/hyperion/>**
+
+Hyperion organises data assets (a *data catalog*), validates them against Avro
+schemas, abstracts storage/queue/cache/secrets backends behind ports and
+adapters, and gives you a framework for writing data **sources**. The same code
+runs on a laptop (local filesystem) or on AWS (S3/DynamoDB/SQS) — the wiring is
+configuration, not code.
+
 ## Features
 
-- **Data Catalog System**: Manage and organize data assets across S3 buckets
-- **Schema Management**: Validate and store schema definitions for data assets
-- **AWS Infrastructure Abstractions**: Simplified interfaces for S3, DynamoDB, SQS, and Secrets Manager
-- **Source Framework**: Define data sources that extract data and store in the catalog
-- **Caching**: In-memory, local file, and DynamoDB caching options
-- **Asynchronous Processing**: Utilities for async operations and task queues
-- **CLI Runner**: Run sources in standalone or Argo Workflow mode with click-based commands
-- **Geo Utilities**: Location-based services with Google Maps integration
-- **Catalog Caching**: Cache downloaded assets for faster repeated access
-- **Asset Collections**: High-level interface for working with groups of assets
-
-## Core Concepts
-
-### Assets
-
-Assets are the fundamental units of data in Hyperion. Each asset represents a dataset stored in a specific location with a defined schema. Hyperion supports three types of assets:
-
-#### DataLakeAsset
-
-- Represents raw, immutable data stored in a data lake
-- Time-partitioned by date
-- Each partition has a schema version
-- Example use cases: raw API responses, event logs, or any source data that needs to be preserved in its original form
-
-#### FeatureAsset
-
-- Represents processed feature data with time resolution
-- Used for analytics, machine learning features, and derived datasets
-- Supports different time resolutions (seconds, minutes, hours, days, weeks, months, years)
-- Can include additional partition keys for finer-grained organization
-- Example use cases: aggregated metrics, processed signals, ML features
-
-#### PersistentStoreAsset
-
-- Represents persistent data storage without time partitioning
-- Used for reference data, lookup tables, or any data that doesn't change frequently
-- Example use cases: reference data, configuration settings, master data
-
-### Schema Management
-
-All assets in Hyperion have associated schemas that define their structure:
-
-- **Schema Store**: The SchemaStore manages asset schemas in Avro format
-- **Schema Validation**: All data is validated against its schema during storage
-- **Schema Versioning**: Assets include a schema version to support evolution over time
-- **Schema Storage**: Schemas can be stored in the local filesystem or S3
-
-If a schema is missing for an asset:
-
-1. An error will be raised when attempting to store or retrieve the asset
-2. You need to define the schema in Avro format and store it in the schema store
-3. The schema should be named according to the pattern: `{asset_type}/{asset_name}.v{version}.avro.json`
-
-### Catalog
-
-The Catalog is the central component that manages asset storage and retrieval:
-
-- **Storage Location**: Maps asset types to their appropriate storage buckets
-- **Asset Retrieval**: Provides methods to retrieve assets by name, date, and schema version
-- **Partitioning**: Handles partitioning logic for different asset types
-- **Notifications**: Can send notifications when new assets arrive
-- **Caching**: Can use a cache for faster repeated retrieval of assets
-
-### Source Framework
-
-Sources are responsible for extracting data from external systems and storing it in the catalog:
-
-- **Standardized Interface**: All sources implement a common interface
-- **AWS Lambda Support**: Easy integration with AWS Lambda for scheduled extraction
-- **Backfill Capability**: Support for historical data backfill
-- **Incremental Processing**: Extract data with date-based filtering
+- **Data Catalog** — manage and organise data assets across backends
+- **Schema management** — validate and store Avro schemas per asset
+- **Ports & adapters** — swap S3/DynamoDB/SQS for local filesystem via config
+- **Source framework** — define sources that extract data into the catalog
+- **Caching** — in-memory, local file, and DynamoDB caching
+- **Asynchronous processing** — utilities for async operations and task queues
+- **CLI runner** — run sources standalone or in "Argo Workflow" mode
+- **Geo utilities** — Haversine math in the lite core; Google Maps via `[geo]`
+- **Asset collections** — a typed, declarative interface over groups of assets
 
 ## Installation
 
-### From PyPI
-
-If you only want to use `hyperion`, you can install it from PyPI:
-
 ```bash
-pip install hyperion-sdk
+pip install 'hyperion-sdk[catalog]'
 # or
-poetry add hyperion-sdk
+poetry add 'hyperion-sdk[catalog]'
 ```
 
-As of `1.0.0` the default install is a slim **lite core**. Heavy backends are opt-in
-extras — install the ones you use:
+As of `1.0.0` the default install is a slim **lite core**; heavy backends are
+opt-in extras — install only the ones you use:
 
 | Extra | Enables |
 |---|---|
@@ -107,495 +49,65 @@ extras — install the ones you use:
 | `hyperion-sdk[snappy]` | snappy-compressed filesystem cache / DynamoDB keyval |
 | `hyperion-sdk[all]` | everything (parity with the pre-1.0 full install) |
 
-For example, the catalog examples below need `pip install 'hyperion-sdk[catalog]'`;
-add `[aws]` as well if you store assets on S3.
+We follow [Semantic Versioning](https://semver.org/) — pin with a selector such
+as `^1.0.0`. **Upgrading from a pre-1.0 release?** Import paths moved and the
+`Catalog` constructor changed — see the
+[migration guide](https://tomasvotava.github.io/hyperion/reference/migration-pre-1.0/)
+(also pinned at the top of [`CHANGELOG.md`](./CHANGELOG.md)).
 
-We follow [Semantic Versioning](https://semver.org/), so you can pin your dependencies to
-a specific version or use a version selector to avoid breaking changes (e.g., `^1.0.0`).
-**Upgrading from a pre-1.0 release?** Import paths moved and the `Catalog` constructor
-changed — see the migration guide at the top of [`CHANGELOG.md`](./CHANGELOG.md).
-
-### From Source
-
-Hyperion uses [Poetry](https://python-poetry.org/) for dependency management:
-
-```bash
-# Clone the repository
-git clone https://github.com/tomasvotava/hyperion.git
-cd hyperion
-
-# Install dependencies
-poetry install
-```
-
-## Configuration
-
-Hyperion is configured through environment variables. You can use a `.env` file for local development:
-
-```bash
-# Common settings
-HYPERION_COMMON_LOG_PRETTY=True
-HYPERION_COMMON_LOG_LEVEL=INFO
-HYPERION_COMMON_SERVICE_NAME=my-service
-
-# Storage settings
-HYPERION_STORAGE_DATA_LAKE_BUCKET=my-data-lake-bucket
-HYPERION_STORAGE_FEATURE_STORE_BUCKET=my-feature-store-bucket
-HYPERION_STORAGE_PERSISTENT_STORE_BUCKET=my-persistent-store-bucket
-HYPERION_STORAGE_SCHEMA_PATH=s3://my-schema-bucket/schemas
-HYPERION_STORAGE_MAX_CONCURRENCY=5
-
-# Queue settings
-## SQS Queue
-HYPERION_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/123456789012/my-queue
-## OR file queue (local)
-HYPERION_QUEUE_PATH=/tmp/hyperion-queue.json
-HYPERION_QUEUE_PATH_OVERWRITE=True                # Overwrite queue file if exists (default: False)
-
-# Secrets settings
-HYPERION_SECRETS_BACKEND=AWSSecretsManager
-
-# HTTP settings (optional)
-HYPERION_HTTP_PROXY_HTTP=http://proxy:8080
-HYPERION_HTTP_PROXY_HTTPS=http://proxy:8080
-
-# Geo settings (optional)
-HYPERION_GEO_GMAPS_API_KEY=your-google-maps-api-key
-
-# Cache settings
-HYPERION_STORAGE_CACHE_DYNAMODB_TABLE=my-cache-table  # Optional DynamoDB table for caching
-HYPERION_STORAGE_CACHE_DYNAMODB_DEFAULT_TTL=3600      # Default TTL for cache items (seconds)
-HYPERION_STORAGE_CACHE_LOCAL_PATH=/tmp/hyperion-cache # Path for local file cache
-HYPERION_STORAGE_CACHE_KEY_PREFIX=my-prefix           # Optional prefix for cache keys
-
-# Source parameters (optional)
-HYPERION_SOURCE_PARAMS={"key": "value"}           # Pass JSON as environment variable to the source
-```
-
-Before any real documentation is written, you can check the
-[`hyperion/config.py`](hyperion/config.py) file for all available configuration options. Hyperion is using [`EnvProxy`](https://github.com/tomasvotava/env-proxy) for configuration.
-
-## Usage Examples
-
-### Working with Assets
-
-#### Creating and Storing a DataLakeAsset
+## Quickstart
 
 ```python
 from hyperion.catalog.catalog import Catalog
 from hyperion.domain.assets import DataLakeAsset
 from datetime import datetime, timezone
 
-# Initialize the catalog
 catalog = Catalog.from_config()
-
-# Create a data lake asset
-asset = DataLakeAsset(
-    name="customer_data",
-    date=datetime.now(timezone.utc),
-    schema_version=1
-)
-
-# Store data in the asset
-data = [
-    {"id": 1, "name": "Customer 1", "timestamp": datetime.now(timezone.utc)},
-    {"id": 2, "name": "Customer 2", "timestamp": datetime.now(timezone.utc)},
-]
-
-catalog.store_asset(asset, data)
+asset = DataLakeAsset(name="customer_data", date=datetime.now(timezone.utc), schema_version=1)
+catalog.store_asset(asset, [{"id": 1, "name": "Customer 1"}])
 ```
 
-#### Working with FeatureAssets
+A runnable, no-AWS walkthrough is in the
+[first DataLakeAsset tutorial](https://tomasvotava.github.io/hyperion/tutorials/first-datalake-asset/).
 
-```python
-from hyperion.catalog.catalog import Catalog
-from hyperion.domain.assets import FeatureAsset
-from hyperion.dateutils import TimeResolution
-from datetime import datetime, timezone
+## Documentation
 
-# Initialize the catalog
-catalog = Catalog.from_config()
+Full documentation is published at **<https://tomasvotava.github.io/hyperion/>**
+and follows the [Diataxis](https://diataxis.fr/) structure:
 
-# Create a feature asset with daily resolution
-resolution = TimeResolution(1, "d")  # 1 day resolution
-asset = FeatureAsset(
-    name="customer_activity",
-    partition_date=datetime.now(timezone.utc),
-    resolution=resolution,
-    schema_version=1
-)
-
-# Store aggregated feature data
-feature_data = [
-    {"customer_id": 1, "activity_score": 87.5, "date": datetime.now(timezone.utc)},
-    {"customer_id": 2, "activity_score": 92.1, "date": datetime.now(timezone.utc)},
-]
-
-catalog.store_asset(asset, feature_data)
-
-# Retrieve feature data for a specific time period
-from_date = datetime(2023, 1, 1, tzinfo=timezone.utc)
-to_date = datetime(2023, 1, 31, tzinfo=timezone.utc)
-
-for feature_asset in catalog.iter_feature_store_partitions(
-    feature_name="customer_activity",
-    resolution="1d",  # Can use string format too
-    date_from=from_date,
-    date_to=to_date
-):
-    data = catalog.retrieve_asset(feature_asset)
-    for record in data:
-        print(record)
-```
-
-#### Working with PersistentStoreAssets
-
-```python
-from hyperion.catalog.catalog import Catalog
-from hyperion.domain.assets import PersistentStoreAsset
-
-# Initialize the catalog
-catalog = Catalog.from_config()
-
-# Create a persistent store asset
-asset = PersistentStoreAsset(
-    name="product_catalog",
-    schema_version=1
-)
-
-# Store reference data
-products = [
-    {"id": "P001", "name": "Product 1", "category": "Electronics"},
-    {"id": "P002", "name": "Product 2", "category": "Clothing"},
-]
-
-catalog.store_asset(asset, products)
-
-# Retrieve reference data
-for product in catalog.retrieve_asset(asset):
-    print(product)
-```
-
-#### Using a Cached Catalog
-
-```python
-from pathlib import Path
-
-from hyperion.catalog.catalog import Catalog
-from hyperion.adapters.cache.filesystem import LocalFileCache
-from hyperion.adapters.storage.filesystem import FilesystemStorage
-from hyperion.adapters.schema_registry.local import LocalSchemaStore
-
-# Create a catalog backed by local storage with a local file cache.
-# (Catalog.from_config() instead wires S3 storage from the environment; it does
-# not configure a cache — pass `cache=` explicitly, as shown here, to enable it.)
-cached_catalog = Catalog(
-    storage=FilesystemStorage("/data/lake"),
-    schema_store=LocalSchemaStore(Path("/data/schemas")),
-    cache=LocalFileCache("catalog", default_ttl=3600, root_path=Path("/tmp/hyperion-cache")),
-)
-
-# First retrieval reads from storage
-data = list(cached_catalog.retrieve_asset(asset))
-
-# Subsequent retrievals will use the cache
-data_again = list(cached_catalog.retrieve_asset(asset))  # Much faster!
-```
-
-### Creating a Custom Source
-
-```python
-import asyncio
-from datetime import datetime, timezone
-from typing import AsyncIterator
-
-from hyperion.catalog.catalog import Catalog
-from hyperion.domain.assets import DataLakeAsset
-from hyperion.sources.base import Source, SourceAsset
-
-
-class MyCustomSource(Source):
-    source = "my-custom-source"
-
-    async def run(self, start_date=None, end_date=None) -> AsyncIterator[SourceAsset]:
-        # Fetch your data (this is where you'd implement your data extraction logic)
-        data = [
-            {"id": 1, "name": "Item 1", "timestamp": datetime.now(timezone.utc)},
-            {"id": 2, "name": "Item 2", "timestamp": datetime.now(timezone.utc)},
-        ]
-
-        # Create asset
-        asset = DataLakeAsset(
-            name="my-custom-data",
-            date=datetime.now(timezone.utc)
-        )
-
-        # Yield source asset
-        yield SourceAsset(asset=asset, data=data)
-
-
-# Use with AWS Lambda
-def lambda_handler(event, context):
-    MyCustomSource.handle_aws_lambda_event(event, context)
-
-
-# Use standalone
-if __name__ == "__main__":
-    asyncio.run(MyCustomSource._run(Catalog.from_config()))
-```
-
-#### Running source directly ('Argo Workflow' mode)
-
-Hyperion provides a `SourceRunner` that generates CLI for your sources.
-
-`running_sources.py`
-
-```python
-from hyperion.sources.cli import SourceRunner
-from my_sources import FirstSource, SecondSource
-
-if __name__ == "__main__":
-    SourceRunner(FirstSource, SecondSource).cli()
-```
-
-You can then invoke your source from the command line:
-
-```bash
-python running_sources.py <first-source | second-source> run \
-    --start-date 2025-01-01 \
-    --end-date 2025-02-01 \
-    --params '{"foo": "bar"}' \
-    --queue-file /argo/output/messages.json \
-    --queue-overwrite
-```
-
-Generated options (all options are optional):
-
-- `--start-date` start date passed on to the source
-- `--end-date` end date passed on to the source
-- `--params` JSON string containing source-specific params
-- `--params-from` a path to JSON file containing source-specific params
-- `--queue-file` output file for queued messages
-- `--queue-overwrite` overwrite queue file if it already exists
-
-The name of the command (`first-source`, `second-source`, etc.) comes from the `source` attribute of your
-`Source` subclass.
-
-### Working with Schemas
-
-To create and register a schema for an asset:
-
-```python
-import json
-from pathlib import Path
-
-# Define schema in Avro format
-schema = {
-    "type": "record",
-    "name": "CustomerData",
-    "fields": [
-        {"name": "id", "type": "int"},
-        {"name": "name", "type": "string"},
-        {"name": "timestamp", "type": {"type": "long", "logicalType": "timestamp-millis"}}
-    ]
-}
-
-# Save schema to local file
-schema_path = Path("schemas/data_lake/customer_data.v1.avro.json")
-schema_path.parent.mkdir(parents=True, exist_ok=True)
-with open(schema_path, "w") as f:
-    json.dump(schema, f)
-
-# Or upload to S3 if using S3SchemaStore
-import boto3
-s3_client = boto3.client('s3')
-s3_client.put_object(
-    Bucket="my-schema-bucket",
-    Key="data_lake/customer_data.v1.avro.json",
-    Body=json.dumps(schema)
-)
-```
-
-## Advanced Features
-
-### Asset Collections
-
-Asset collections provide a high-level interface for fetching and working with groups of assets. You can define a collection class that specifies the assets you need and fetch them all at once.
-
-See [`docs/asset_collections.md`](docs/asset_collections.md) for more information.
-
-### Repartitioning Data
-
-```python
-from hyperion.catalog.catalog import Catalog
-from hyperion.domain.assets import DataLakeAsset
-from hyperion.dateutils import TimeResolutionUnit
-from datetime import datetime, timezone
-import asyncio
-
-async def repartition_data():
-    catalog = Catalog.from_config()
-
-    # Original asset with day-level partitioning
-    asset = DataLakeAsset(
-        name="web_logs",
-        date=datetime.now(timezone.utc),
-        schema_version=1
-    )
-
-    # Repartition by hour
-    await catalog.repartition(
-        asset,
-        granularity=TimeResolutionUnit("h"),
-        date_attribute="timestamp"
-    )
-
-asyncio.run(repartition_data())
-```
-
-### Caching
-
-Hyperion provides two types of caching:
-
-1. **Key-Value Cache**: For general-purpose caching of any data
-2. **Catalog Asset Cache**: For efficient retrieval of assets from storage
-
-#### Key-Value Cache
-
-```python
-from hyperion.ports.cache import Cache
-
-# Get cache from configuration
-cache = Cache.from_config()
-
-# Store data in cache
-cache.set("my-key", "my-value")
-
-# Retrieve data from cache
-value = cache.get("my-key")
-print(value)  # "my-value"
-
-# Check if key exists
-if cache.hit("my-key"):
-    print("Cache hit!")
-
-# Delete key
-cache.delete("my-key")
-```
-
-#### Catalog Asset Cache
-
-```python
-from pathlib import Path
-
-from hyperion.catalog.catalog import Catalog
-from hyperion.adapters.cache.filesystem import LocalFileCache
-from hyperion.adapters.storage.filesystem import FilesystemStorage
-
-# Asset caching requires a cache to be injected into the Catalog.
-# Catalog.from_config() wires storage from the environment but does NOT
-# configure a cache, so pass `cache=` explicitly to enable caching.
-catalog = Catalog(
-    storage=FilesystemStorage("/data/lake"),
-    cache=LocalFileCache("catalog", root_path=Path("/tmp/hyperion-cache")),
-)
-
-# Now asset retrievals will be cached
-# First time: reads from storage
-data1 = list(catalog.retrieve_asset(asset1))
-
-# Second time: uses cache
-data1_again = list(catalog.retrieve_asset(asset1))  # Much faster!
-
-# Different asset: reads from storage
-data2 = list(catalog.retrieve_asset(asset2))
-
-# Force bypass cache for a specific retrieval
-with catalog._get_asset_file_handle(asset, no_cache=True) as file:
-    # Process file directly without using cache
-    pass
-```
-
-### Geo Utilities
-
-```python
-from hyperion.adapters.geocoder.google import GoogleMaps
-from hyperion.domain.geo import Location
-
-# Initialize Google Maps client
-gmaps = GoogleMaps.from_config()
-
-# Geocode an address
-with gmaps:
-    location = gmaps.geocode("1600 Amphitheatre Parkway, Mountain View, CA")
-    print(f"Latitude: {location.latitude}, Longitude: {location.longitude}")
-
-    # Reverse geocode a location
-    named_location = gmaps.reverse_geocode(location)
-    print(f"Address: {named_location.address}")
-    print(f"Country: {named_location.country}")
-```
+- [Tutorials](https://tomasvotava.github.io/hyperion/tutorials/) — learning-oriented walkthroughs
+- [How-to guides](https://tomasvotava.github.io/hyperion/how-to/) — task-oriented recipes
+- [Reference](https://tomasvotava.github.io/hyperion/reference/migration-pre-1.0/) — auto-generated API reference + migration guide
+- [Explanation](https://tomasvotava.github.io/hyperion/explanation/) — architecture and design
 
 ## Development
 
-### Setup Development Environment
+Hyperion uses [Poetry](https://python-poetry.org/):
 
 ```bash
-# Install development dependencies
+git clone https://github.com/tomasvotava/hyperion.git
+cd hyperion
 poetry install
-
-# Install pre-commit hooks
 poetry run pre-commit install
+
+poetry run pytest                  # run tests
+poetry run pre-commit run -a       # ruff + mypy + hooks
+poetry install --with docs         # docs toolchain
+poetry run mkdocs serve            # preview the docs site locally
 ```
 
-### Running Tests
-
-```bash
-# Run all tests
-poetry run pytest
-
-# Run with coverage
-poetry run pytest --cov=hyperion
-
-# Run specific test files
-poetry run pytest tests/test_asyncutils.py
-```
-
-### Code Style
-
-This project uses [pre-commit](https://pre-commit.com/) hooks to enforce code style:
-
-```bash
-# Run pre-commit on all files
-poetry run pre-commit run -a
-```
-
-The project uses:
-
-- [ruff](https://github.com/charliermarsh/ruff) for linting
-- [mypy](https://mypy.readthedocs.io/) for type checking
-- [commitizen](https://github.com/commitizen-tools/commitizen) for standardized commits
-
-## Architecture
-
-### Core Components
-
-- **Catalog**: Manages data assets and their storage in S3
-- **SchemaStore**: Handles schema validation and storage
-- **Source**: Base class for implementing data sources
-- **Infrastructure**: Abstractions for AWS services (S3, DynamoDB, SQS, etc.)
-- **Utils**: Helper functions for dates, async operations, etc.
-
-### Asset Types
-
-- **DataLakeAsset**: Raw data stored in a data lake
-- **FeatureAsset**: Processed features with time resolution
-- **PersistentStoreAsset**: Persistent data storage
+The project uses [ruff](https://github.com/astral-sh/ruff) (linting),
+[mypy](https://mypy.readthedocs.io/) (type checking), and
+[commitizen](https://github.com/commitizen-tools/commitizen) (conventional
+commits). See the
+[architecture explanation](https://tomasvotava.github.io/hyperion/explanation/architecture/)
+for the layered design.
 
 ## Contributing
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines on contributing to this project.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.
 
 ## License
 
-This project is licensed under the MIT License - see the LICENSE file for details.
+This project is licensed under the MIT License — see the LICENSE file for
+details.

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -1,0 +1,52 @@
+# Architecture
+
+Hyperion is organised as a set of **layers** following a ports-and-adapters
+(hexagonal / DDD) design. The goal: the same orchestration code runs on a
+laptop or on AWS, and which backend is used is a *configuration* decision made
+in exactly one place.
+
+## The layers
+
+| Layer | Package | Responsibility | May depend on |
+|---|---|---|---|
+| **Domain** | `hyperion.domain` | Pure asset identities, messages, geo math. No I/O. | lite core only |
+| **Ports** | `hyperion.ports` | Abstract contracts: `StoragePort`, `Cache`, `Queue`, `SchemaStore`, `SecretsManager`, `KeyValueStore`, `Geocoder`. | domain |
+| **Adapters** | `hyperion.adapters` | Concrete backends (memory / filesystem / S3 / DynamoDB / SQS / Google Maps / avro). | domain, ports |
+| **Application** | `hyperion.catalog.catalog`, `hyperion.application` | Orchestration — the `Catalog`. Depends on ports, never on adapters. | domain, ports |
+| **Composition** | `hyperion.composition` | The only module that imports *both* ports and adapters and builds adapters from config. | everything |
+| **Data** | `hyperion.data` | The pandera/polars validation stack — a leaf, behind `[data]`. | domain |
+
+The lite core (`hyperion.log`, `hyperion.config`, `hyperion.dateutils`,
+`hyperion.asyncutils`, `hyperion.typeutils`) sits below all of this and is
+always installed.
+
+## How a request flows
+
+`Catalog.from_config()` asks the **composition root** for adapters; the
+composition root reads `hyperion.config` and constructs the concrete `S3Storage`
+/ `LocalSchemaStore` / cache / queue that the environment selects. The
+`Catalog` then talks only to the **port** interfaces — it never imports an
+adapter (the one documented carve-out is the avro serializer). Swapping
+filesystem for S3 changes configuration, not the `Catalog` code.
+
+```
+config ──> composition root ──constructs──> adapters (S3 / filesystem / …)
+                  │                              │ implement
+                  └──> Catalog ── depends on ──> ports (StoragePort, Cache, …)
+```
+
+A **Source** sits on top: it extracts external data and yields assets that the
+`Catalog` stores; messages about arrivals flow through the `Queue` port.
+
+## Why this shape
+
+- **Testability** — the application tier is exercised with in-memory adapters,
+  no AWS.
+- **Optionality** — heavy backends live in adapters and are gated by extras
+  (see [Lite core and extras](extras-and-lite-core.md)); the lite core stays
+  dependency-light.
+- **One wiring point** — backend selection is centralised in the composition
+  root instead of being scattered through call sites.
+
+The precise "who may import whom" rules and how they are enforced are covered
+in [Ports and adapters](ports-and-adapters.md).

--- a/docs/explanation/assets-and-catalog.md
+++ b/docs/explanation/assets-and-catalog.md
@@ -1,0 +1,58 @@
+# Assets and the Catalog
+
+## Assets
+
+Assets are the fundamental units of data in Hyperion. Each asset represents a
+dataset stored in a specific location with a defined schema. There are three
+types:
+
+### DataLakeAsset
+
+- Raw, immutable data stored in a data lake.
+- Time-partitioned by date; each partition has a schema version.
+- Use for: raw API responses, event logs, source data preserved as-is.
+
+### FeatureAsset
+
+- Processed feature data with a **time resolution** (seconds → years).
+- Can carry additional partition keys for finer-grained organisation.
+- Use for: aggregated metrics, processed signals, ML features.
+
+### PersistentStoreAsset
+
+- Persistent data **without** time partitioning.
+- Use for: reference data, lookup tables, configuration, master data.
+
+## Schema management
+
+Every asset has an associated Avro schema:
+
+- **Schema store** — the `SchemaStore` port manages schemas in Avro format,
+  backed by the local filesystem or S3.
+- **Validation** — data is validated against its schema on storage.
+- **Versioning** — assets carry a `schema_version` to support evolution.
+- **Naming** — `{asset_type}/{asset_name}.v{version}.avro.json`.
+
+A missing schema is an error, not a silent pass: storing or retrieving raises
+until the schema is registered. See
+[Register and use schemas](../how-to/schemas.md).
+
+## The Catalog
+
+The `Catalog` is the central orchestrator for asset storage and retrieval:
+
+- **Storage routing** — maps each asset type to its storage backend (a single
+  `StoragePort`, or a mapping per asset type).
+- **Retrieval** — fetch assets by name, date, and schema version; iterate
+  feature partitions over a date range.
+- **Partitioning** — owns the partitioning logic per asset type, including
+  repartitioning.
+- **Notifications** — can emit messages (via the `Queue` port) when assets
+  arrive.
+- **Caching** — can use an injected cache for fast repeated retrieval (caching
+  is opt-in; `from_config()` does not attach one — see
+  [Use a cached Catalog](../how-to/cached-catalog.md)).
+
+The `Catalog` depends only on the port interfaces; the concrete backends are
+chosen by the composition root — see
+[Ports and adapters](ports-and-adapters.md).

--- a/docs/explanation/extras-and-lite-core.md
+++ b/docs/explanation/extras-and-lite-core.md
@@ -1,0 +1,53 @@
+# Lite core and extras
+
+As of `1.0.0`, `pip install hyperion-sdk` installs a slim **lite core**. Heavy
+backends are opt-in extras. This page explains the split and the reasoning.
+
+## What is always installed
+
+The lite core pulls only light, pure-Python-ish dependencies: `loguru`,
+`pydantic`, `httpx`, `python-dateutil`, `python-dotenv`, `env-proxy`,
+`cachetools`, `click`, `haversine`, `aws-lambda-typing`.
+
+That is enough for the domain layer, the ports, configuration, logging, date
+utilities, async utilities, Haversine geo math, and the in-memory / filesystem
+adapters.
+
+## The extras
+
+| Extra | Pulls | Enables |
+|---|---|---|
+| `[aws]` | `boto3`, `aioboto3` | every `adapters/*/dynamodb`, `s3`, `sqs`, `aws_sm` (DynamoDB cache/keyval, S3 storage/schema, SQS queue, AWS Secrets Manager) |
+| `[data]` | `polars`, `pandera`, `numpy` | `hyperion.data.*` (pandera↔polars typing, asset schemas, `SpatialKMeans`) |
+| `[catalog]` | `fastavro` | `hyperion.adapters.serialization.avro` (avro-backed `Catalog`) |
+| `[geo]` | `googlemaps` | `hyperion.adapters.geocoder.google` (`GoogleMaps`); Haversine math stays lite |
+| `[snappy]` | `python-snappy` | compressed filesystem cache / DynamoDB keyval (graceful no-compression fallback when absent) |
+| `[all]` | union of the above | parity with the pre-1.0 full install |
+
+`[catalog]` no longer transitively requires `[aws]`: a `Catalog` backed by
+local filesystem storage works with `[catalog]` alone.
+
+## Why split it
+
+- **Smaller, faster installs** — most consumers don't need `boto3` *and*
+  `polars` *and* `googlemaps`. A source running in a constrained Lambda or a
+  CLI tool only pays for what it uses.
+- **Clear capability boundaries** — the extras map one-to-one onto adapter
+  families, so "what do I need to install?" has a mechanical answer.
+- **Architecturally enforced** — the lite-core promise (the core pulls no heavy
+  third-party) is verified separately by the import-graph test and a
+  no-extras smoke job, complementing the internal layering contract described
+  in [Ports and adapters](ports-and-adapters.md).
+
+## Picking extras
+
+Install the capabilities you use, e.g.:
+
+```bash
+pip install 'hyperion-sdk[catalog,aws]'   # Catalog on S3
+pip install 'hyperion-sdk[data]'          # feature models / asset collections
+pip install 'hyperion-sdk[all]'           # everything (pre-1.0 parity)
+```
+
+See the task-focused [Install Hyperion and pick extras](../how-to/install-and-extras.md)
+guide for combinations and version pinning.

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -1,0 +1,16 @@
+# Explanation
+
+Understanding-oriented background. These pages explain *why* Hyperion is shaped
+the way it is — read them when you want the mental model, not a recipe.
+
+- **[Architecture](architecture.md)** — the layered (DDD) design and how a
+  request flows through it.
+- **[Assets and the Catalog](assets-and-catalog.md)** — the three asset types,
+  schemas, and what the `Catalog` is responsible for.
+- **[Ports and adapters](ports-and-adapters.md)** — the dependency-inversion
+  layout, the composition root, and the enforced layering contract.
+- **[Lite core and extras](extras-and-lite-core.md)** — why the default install
+  is slim and how the extras map to capabilities.
+
+For the concrete upgrade steps from a pre-1.0 release, see
+[Migrating from pre-1.0](../reference/migration-pre-1.0.md).

--- a/docs/explanation/ports-and-adapters.md
+++ b/docs/explanation/ports-and-adapters.md
@@ -1,0 +1,66 @@
+# Ports and adapters
+
+Hyperion uses dependency inversion: the application tier depends on **abstract
+contracts** (ports), and **concrete backends** (adapters) implement them. The
+binding between the two happens in exactly one place — the composition root.
+
+## Ports
+
+`hyperion.ports` holds the interfaces:
+
+- `StoragePort` — object storage
+- `Cache` — caching
+- `KeyValueStore` — key-value persistence
+- `Queue` — message queue
+- `SecretsManager` — secret retrieval
+- `SchemaStore` — Avro schema registry
+- `Geocoder` — geocoding
+
+Ports depend only on the domain and the lite core. They may *lazily* delegate
+to the composition root for their `from_config()` factories, but they never
+import an adapter.
+
+## Adapters
+
+`hyperion.adapters` holds the implementations, grouped by capability and by
+backend, e.g. `adapters.storage.{memory,filesystem,s3}`,
+`adapters.cache.{memory,filesystem,dynamodb}`, `adapters.queue.{…,sqs}`,
+`adapters.geocoder.{static,google}`, `adapters.serialization.avro`. Heavy
+backends are gated by [extras](extras-and-lite-core.md). An adapter may import
+the domain and the ports it implements — but never the application tier or the
+composition root.
+
+## The composition root
+
+`hyperion.composition` is the **only** module allowed to import both
+`hyperion.ports` and `hyperion.adapters`. It reads `hyperion.config` and
+constructs the adapter the environment selects. This is what makes
+`Catalog.from_config()` (and `Cache.from_config()`, `GoogleMaps.from_config()`,
+…) possible without the `Catalog` ever knowing S3 exists.
+
+## The layering contract is enforced
+
+These rules are not just convention — they are checked in CI by
+[import-linter](https://import-linter.readthedocs.io/) (`.importlinter`):
+
+- `domain` depends on nothing but the lite core.
+- `ports` do not reach into adapters / application / data / catalog.
+- `application` / `catalog.catalog` never import adapters (one documented
+  carve-out: the avro serializer).
+- `adapters` never import application / catalog / composition.
+- `data` is a leaf — no live layer imports it.
+- by the conjunction of the above, only `composition` imports both ports and
+  adapters.
+
+The deprecation shims (`hyperion.entities`, `hyperion.infrastructure.*`, the
+`hyperion.catalog` namespace shim, the pandera/polars parts of
+`hyperion.typeutils`) are intentionally *not* layer-constrained: they exist
+only to redirect old import paths and are removed in 2.0 — see
+[Migrating from pre-1.0](../reference/migration-pre-1.0.md).
+
+## Why injection over configuration on the Catalog
+
+Caches, queues and schema stores are *injected* into the `Catalog` constructor
+rather than configured on it. This keeps the `Catalog` agnostic of any backend,
+makes it trivial to test with in-memory adapters, and means new backends are
+added as adapters without touching the orchestration code.

--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -1,0 +1,103 @@
+"""mkdocs-gen-files generator: one API-reference page per public v1.0 module.
+
+This script is run by the ``gen-files`` mkdocs plugin at build time. It writes
+``reference/<path>.md`` (each just a ``:::`` mkdocstrings autodoc directive) plus
+``reference/SUMMARY.md`` which ``literate-nav`` consumes to build the Reference
+navigation. Nothing it writes is committed (see ``.gitignore``).
+
+The module list is an *explicit allow-list* of the v1.0 public surface. The
+deprecation shims -- ``hyperion.entities.*``, ``hyperion.infrastructure.*``,
+the ``hyperion.catalog`` package shim, ``hyperion.application.persistent_cache``,
+``hyperion.catalog.schema``, ``hyperion._compat`` -- are intentionally absent so
+they never appear in the published reference. (griffe analyses statically and
+never executes the PEP-562 ``__getattr__`` shims anyway; the allow-list is the
+single source of truth for "what is v1.0 public".)
+
+Lives outside ``hyperion/`` and ``tests/`` so it is not covered by the
+pre-commit ``mypy hyperion tests`` / ``ruff check hyperion tests`` hooks.
+"""
+
+from pathlib import Path
+
+import mkdocs_gen_files
+
+PUBLIC_MODULES = [
+    # Catalog orchestration
+    "hyperion.catalog.catalog",
+    # Domain layer (pure)
+    "hyperion.domain.assets",
+    "hyperion.domain.messages",
+    "hyperion.domain.geo",
+    # Ports (interfaces)
+    "hyperion.ports.cache",
+    "hyperion.ports.storage",
+    "hyperion.ports.queue",
+    "hyperion.ports.schema_registry",
+    "hyperion.ports.secrets",
+    "hyperion.ports.keyval",
+    "hyperion.ports.geocoder",
+    # Adapters (concrete backends)
+    "hyperion.adapters.storage.s3",
+    "hyperion.adapters.storage.filesystem",
+    "hyperion.adapters.storage.memory",
+    "hyperion.adapters.cache.dynamodb",
+    "hyperion.adapters.cache.filesystem",
+    "hyperion.adapters.cache.memory",
+    "hyperion.adapters.keyval.dynamodb",
+    "hyperion.adapters.keyval.filesystem",
+    "hyperion.adapters.keyval.memory",
+    "hyperion.adapters.queue.sqs",
+    "hyperion.adapters.queue.filesystem",
+    "hyperion.adapters.queue.memory",
+    "hyperion.adapters.secrets.aws_sm",
+    "hyperion.adapters.secrets.env",
+    "hyperion.adapters.secrets.dummy",
+    "hyperion.adapters.schema_registry.s3",
+    "hyperion.adapters.schema_registry.local",
+    "hyperion.adapters.geocoder.google",
+    "hyperion.adapters.geocoder.static",
+    "hyperion.adapters.serialization.avro",
+    "hyperion.adapters.http.proxy",
+    # Composition root
+    "hyperion.composition",
+    # Sources framework
+    "hyperion.sources.base",
+    "hyperion.sources.cli",
+    # Repository / collections
+    "hyperion.repository.asset_collection",
+    # Data validation (requires the [data] extra)
+    "hyperion.data.asset_schemas",
+    # Lite-core utilities
+    "hyperion.config",
+    "hyperion.dateutils",
+    "hyperion.asyncutils",
+    "hyperion.typeutils",
+    "hyperion.log",
+]
+
+nav = mkdocs_gen_files.Nav()
+
+for dotted in PUBLIC_MODULES:
+    parts = dotted.split(".")
+    rel = Path(*parts[1:])  # drop the leading "hyperion"
+    doc_path = Path("reference", rel).with_suffix(".md")
+
+    nav[tuple(parts[1:])] = doc_path.relative_to("reference").as_posix()
+
+    with mkdocs_gen_files.open(doc_path, "w") as fd:
+        fd.write(f"# `{dotted}`\n\n::: {dotted}\n")
+
+    mkdocs_gen_files.set_edit_path(
+        doc_path,
+        f"https://github.com/tomasvotava/hyperion/blob/master/{Path(*parts)}.py",
+    )
+
+# The whole Reference section is literate-nav driven from this SUMMARY.md
+# (mkdocs.yml has a single `- Reference: reference/` entry). Prepend the
+# hand-written migration page, then nest the generated API tree under an
+# "API reference" section.
+with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as fd:
+    fd.write("* [Migrating from pre-1.0](migration-pre-1.0.md)\n")
+    fd.write("* API reference\n")
+    for line in nav.build_literate_nav():
+        fd.write("    " + line)

--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -87,11 +87,6 @@ for dotted in PUBLIC_MODULES:
     with mkdocs_gen_files.open(doc_path, "w") as fd:
         fd.write(f"# `{dotted}`\n\n::: {dotted}\n")
 
-    mkdocs_gen_files.set_edit_path(
-        doc_path,
-        f"https://github.com/tomasvotava/hyperion/blob/master/{Path(*parts)}.py",
-    )
-
 # The whole Reference section is literate-nav driven from this SUMMARY.md
 # (mkdocs.yml has a single `- Reference: reference/` entry). Prepend the
 # hand-written migration page, then nest the generated API tree under an

--- a/docs/how-to/asset-collections.md
+++ b/docs/how-to/asset-collections.md
@@ -1,6 +1,7 @@
-# Asset Collections in Hyperion
+# Fetch data with Asset Collections
 
-Asset Collections provide a type-safe, declarative way to fetch and work with data assets from the Hyperion catalog.
+Asset Collections provide a type-safe, declarative way to fetch and work with
+data assets from the Hyperion catalog.
 
 ## Overview
 
@@ -12,13 +13,14 @@ The `AssetCollection` system makes it easy to:
 - Control concurrency during fetching
 - Work with either Pydantic models or Polars DataFrames
 
-## Basic Usage
+## Basic usage
 
-### 1. Define a Feature Model
+### 1. Define a feature model
 
-You can define feature models using either Pydantic (for object-oriented data) or Pandera with Polars (for large datasets).
+You can define feature models using either Pydantic (for object-oriented data)
+or Pandera with Polars (for large datasets).
 
-#### Option A: Pydantic Model
+#### Option A: Pydantic model
 
 Create a model class that extends both `FeatureModel` and `pydantic.BaseModel`.
 Feature models live in `hyperion.data`, so this requires the `[data]` extra
@@ -41,9 +43,10 @@ class WeatherFeature(FeatureModel, BaseModel):
     humidity: float
 ```
 
-#### Option B: Polars Model with Pandera
+#### Option B: Polars model with Pandera
 
-For large datasets or analytics workloads, create a model using `PolarsFeatureModel`:
+For large datasets or analytics workloads, create a model using
+`PolarsFeatureModel`:
 
 ```python
 import polars as pl
@@ -63,7 +66,7 @@ class WeatherPolarsFeature(PolarsFeatureModel):
     humidity: pt.Series[Float64]
 ```
 
-### 2. Create an Asset Collection
+### 2. Create an asset collection
 
 Define a collection class that declares what feature data you need:
 
@@ -86,7 +89,7 @@ class WeatherDataCollection(AssetCollection):
     )
 ```
 
-### 3. Fetch and Use the Data
+### 3. Fetch and use the data
 
 ```python
 # Fetch all data asynchronously
@@ -106,9 +109,9 @@ historical_df = WeatherDataCollection.historical_weather.collect()
 print(f"Records: {len(historical_df)}")
 ```
 
-## Advanced Features
+## Advanced features
 
-### Custom Catalog
+### Custom catalog
 
 You can specify a custom catalog for your collection:
 
@@ -119,36 +122,34 @@ class CustomCollection(AssetCollection):
     weather_polars = PolarsFeatureFetchSpecifier(WeatherPolarsFeature)
 ```
 
-### Concurrency Control
+### Concurrency control
 
 Control how many concurrent fetches are allowed:
 
 ```python
 class LimitedConcurrencyCollection(AssetCollection):
-    max_concurrency: ClassVar = 4  # Limit to 4 concurrent requests
+    max_concurrency: ClassVar = 4  # limit to 4 concurrent requests
     weather = FeatureFetchSpecifier(WeatherFeature)
 ```
 
-### Reset Data
+### Reset data
 
 Clear fetched data to fetch again:
 
 ```python
-# Clear all data
 WeatherDataCollection.clear()
-
-# Fetch fresh data
 await WeatherDataCollection.fetch_all()
 ```
 
-## Working with Polars Data
+## Working with Polars data
 
-When using `PolarsFeatureFetchSpecifier`, you get a LazyFrame with the following benefits:
+When using `PolarsFeatureFetchSpecifier`, you get a LazyFrame with the
+following benefits:
 
-1. **Lazy Evaluation**: Operations are only executed when you call `.collect()`
-2. **Query Optimization**: Polars optimizes the execution plan
-3. **Memory Efficiency**: Great for working with millions of rows
-4. **Type Safety**: Full schema validation through Pandera
+1. **Lazy evaluation**: operations execute only when you call `.collect()`
+2. **Query optimization**: Polars optimises the execution plan
+3. **Memory efficiency**: great for working with millions of rows
+4. **Type safety**: full schema validation through Pandera
 
 Example operations:
 
@@ -167,40 +168,42 @@ monthly_avg = WeatherDataCollection.historical_weather.group_by(
 ).collect()
 ```
 
-## Important Notes
+## Important notes
 
-1. **Shared Data**: All instances of a collection class share the same data.
-
-2. **Lazy Fetching**: Data is not fetched until `fetch_all()` is called.
-
-3. **Class-level API**: Most methods are class methods, not instance methods.
-
+1. **Shared data**: all instances of a collection class share the same data.
+2. **Lazy fetching**: data is not fetched until `fetch_all()` is called.
+3. **Class-level API**: most methods are class methods, not instance methods.
 4. **Requirements**:
-   - Pydantic models must have `asset_name` and `resolution` class variables
-   - Polars models must have `_asset_name` and `_resolution` class variables
+    - Pydantic models must have `asset_name` and `resolution` class variables
+    - Polars models must have `_asset_name` and `_resolution` class variables
+5. **Data size considerations**:
+    - Use Pydantic models for smaller datasets and object-oriented manipulation
+    - Use Polars models for large datasets (millions of rows) and analytics
 
-5. **Data Size Considerations**:
-   - Use Pydantic models for smaller datasets and when you need object-oriented manipulation
-   - Use Polars models for large datasets (millions of rows) and analytical operations
-
-## Date Specifications
+## Date specifications
 
 You can specify date ranges in multiple ways:
 
-- **Absolute dates**: Use `datetime` objects
-- **Relative dates**: Use `timedelta` objects (negative for past, positive for future)
-- **Mixed**: Combine absolute and relative dates
+- **Absolute dates**: use `datetime` objects
+- **Relative dates**: use `timedelta` objects (negative for past, positive for future)
+- **Mixed**: combine absolute and relative dates
 
 A date specification of `None` means:
 
-- For `start_date`: Use minimum date (fetch all historical data)
-- For `end_date`: Use current time (fetch up to now)
+- For `start_date`: use the minimum date (fetch all historical data)
+- For `end_date`: use the current time (fetch up to now)
 
-## Coming Soon
+## Coming soon
 
 Future versions will include:
 
-- Enhanced Polars streaming capabilities for extremely large datasets
+- Enhanced Polars streaming for extremely large datasets
 - Column projection to reduce I/O for large datasets
 - Support for DataLake and PersistentStore assets
 - Advanced caching strategies for feature data
+
+## See also
+
+- [Work with FeatureAssets](feature-assets.md) for the lower-level API.
+- The [`hyperion.repository.asset_collection`](../reference/repository/asset_collection.md)
+  API reference.

--- a/docs/how-to/cached-catalog.md
+++ b/docs/how-to/cached-catalog.md
@@ -1,0 +1,71 @@
+# Use a cached Catalog
+
+`Catalog.from_config()` wires storage from the environment but does **not**
+attach a cache. To make repeated asset retrievals fast, inject a cache adapter
+into the `Catalog` constructor explicitly.
+
+## Catalog backed by local storage + a local file cache
+
+```python
+from pathlib import Path
+
+from hyperion.catalog.catalog import Catalog
+from hyperion.adapters.cache.filesystem import LocalFileCache
+from hyperion.adapters.storage.filesystem import FilesystemStorage
+from hyperion.adapters.schema_registry.local import LocalSchemaStore
+
+cached_catalog = Catalog(
+    storage=FilesystemStorage("/data/lake"),
+    schema_store=LocalSchemaStore(Path("/data/schemas")),
+    cache=LocalFileCache("catalog", default_ttl=3600, root_path=Path("/tmp/hyperion-cache")),
+)
+
+data = list(cached_catalog.retrieve_asset(asset))        # reads from storage
+data_again = list(cached_catalog.retrieve_asset(asset))  # served from cache
+```
+
+## Add a cache to any storage backend
+
+The same pattern works with any storage adapter — only `cache=` is required to
+enable asset caching:
+
+```python
+catalog = Catalog(
+    storage=FilesystemStorage("/data/lake"),
+    cache=LocalFileCache("catalog", root_path=Path("/tmp/hyperion-cache")),
+)
+
+data1 = list(catalog.retrieve_asset(asset1))        # reads from storage
+data1_again = list(catalog.retrieve_asset(asset1))  # served from cache
+data2 = list(catalog.retrieve_asset(asset2))        # different asset → storage
+```
+
+Available cache adapters: `hyperion.adapters.cache.memory.InMemoryCache`,
+`hyperion.adapters.cache.filesystem.LocalFileCache`, and
+`hyperion.adapters.cache.dynamodb.DynamoDBCache` (requires the `[aws]` extra).
+
+## General-purpose key-value cache
+
+Independently of the catalog, you can use a cache directly for any data. Build
+one from configuration via the `Cache` port:
+
+```python
+from hyperion.ports.cache import Cache
+
+cache = Cache.from_config()
+
+cache.set("my-key", "my-value")
+print(cache.get("my-key"))   # "my-value"
+
+if cache.hit("my-key"):
+    print("Cache hit!")
+
+cache.delete("my-key")
+```
+
+## See also
+
+- [Configure backends via environment](configure-via-environment.md) for the
+  `HYPERION_STORAGE_CACHE_*` variables.
+- [Ports and adapters](../explanation/ports-and-adapters.md) for why caches are
+  injected rather than configured on the `Catalog`.

--- a/docs/how-to/configure-via-environment.md
+++ b/docs/how-to/configure-via-environment.md
@@ -1,0 +1,59 @@
+# Configure backends via environment
+
+Hyperion is configured through environment variables (via
+[`EnvProxy`](https://github.com/tomasvotava/env-proxy)).
+`Catalog.from_config()`, `Cache.from_config()`, `GoogleMaps.from_config()` and
+the other `*.from_config()` factories read these and wire the right adapters —
+so the same code runs locally or on AWS by changing configuration only.
+
+For local development you can put these in a `.env` file:
+
+```bash
+# Common settings
+HYPERION_COMMON_LOG_PRETTY=True
+HYPERION_COMMON_LOG_LEVEL=INFO
+HYPERION_COMMON_SERVICE_NAME=my-service
+
+# Storage settings
+HYPERION_STORAGE_DATA_LAKE_BUCKET=my-data-lake-bucket
+HYPERION_STORAGE_FEATURE_STORE_BUCKET=my-feature-store-bucket
+HYPERION_STORAGE_PERSISTENT_STORE_BUCKET=my-persistent-store-bucket
+HYPERION_STORAGE_SCHEMA_PATH=s3://my-schema-bucket/schemas
+HYPERION_STORAGE_MAX_CONCURRENCY=5
+
+# Queue settings
+## SQS Queue
+HYPERION_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/123456789012/my-queue
+## OR file queue (local)
+HYPERION_QUEUE_PATH=/tmp/hyperion-queue.json
+HYPERION_QUEUE_PATH_OVERWRITE=True   # overwrite queue file if it exists (default: False)
+
+# Secrets settings
+HYPERION_SECRETS_BACKEND=AWSSecretsManager
+
+# HTTP settings (optional)
+HYPERION_HTTP_PROXY_HTTP=http://proxy:8080
+HYPERION_HTTP_PROXY_HTTPS=http://proxy:8080
+
+# Geo settings (optional)
+HYPERION_GEO_GMAPS_API_KEY=your-google-maps-api-key
+
+# Cache settings
+HYPERION_STORAGE_CACHE_DYNAMODB_TABLE=my-cache-table   # optional DynamoDB cache table
+HYPERION_STORAGE_CACHE_DYNAMODB_DEFAULT_TTL=3600       # default cache TTL (seconds)
+HYPERION_STORAGE_CACHE_LOCAL_PATH=/tmp/hyperion-cache  # local file cache path
+HYPERION_STORAGE_CACHE_KEY_PREFIX=my-prefix            # optional cache-key prefix
+
+# Source parameters (optional)
+HYPERION_SOURCE_PARAMS={"key": "value"}                # JSON passed to the source
+```
+
+The authoritative list of every configuration option is the
+[`hyperion.config`](../reference/config.md) module in the API reference (its
+source mirrors the environment variable names).
+
+!!! tip "`from_config()` does not configure a cache"
+    `Catalog.from_config()` wires storage (and queue/schema) from the
+    environment but does **not** attach a cache. To enable asset caching pass
+    `cache=` to the `Catalog` constructor explicitly — see
+    [Use a cached Catalog](cached-catalog.md).

--- a/docs/how-to/feature-assets.md
+++ b/docs/how-to/feature-assets.md
@@ -1,0 +1,56 @@
+# Work with FeatureAssets
+
+A `FeatureAsset` represents processed feature data at a given **time
+resolution** (for analytics or ML features), optionally with extra partition
+keys. Use it when data is time-bucketed rather than raw.
+
+## Store a feature asset
+
+```python
+from hyperion.catalog.catalog import Catalog
+from hyperion.domain.assets import FeatureAsset
+from hyperion.dateutils import TimeResolution
+from datetime import datetime, timezone
+
+catalog = Catalog.from_config()
+
+resolution = TimeResolution(1, "d")  # 1-day resolution
+asset = FeatureAsset(
+    name="customer_activity",
+    partition_date=datetime.now(timezone.utc),
+    resolution=resolution,
+    schema_version=1,
+)
+
+catalog.store_asset(asset, [
+    {"customer_id": 1, "activity_score": 87.5, "date": datetime.now(timezone.utc)},
+    {"customer_id": 2, "activity_score": 92.1, "date": datetime.now(timezone.utc)},
+])
+```
+
+## Iterate a time range
+
+`iter_feature_store_partitions` yields the `FeatureAsset` for each partition in
+a date range; retrieve each one to read its records:
+
+```python
+from_date = datetime(2023, 1, 1, tzinfo=timezone.utc)
+to_date = datetime(2023, 1, 31, tzinfo=timezone.utc)
+
+for feature_asset in catalog.iter_feature_store_partitions(
+    feature_name="customer_activity",
+    resolution="1d",          # string form accepted too
+    date_from=from_date,
+    date_to=to_date,
+):
+    for record in catalog.retrieve_asset(feature_asset):
+        print(record)
+```
+
+## See also
+
+- [Repartition data](repartition-data.md) to change partition granularity.
+- [Fetch data with Asset Collections](asset-collections.md) for a typed,
+  declarative interface over many feature assets at once.
+- [Assets and the Catalog](../explanation/assets-and-catalog.md) for the
+  concepts behind asset types.

--- a/docs/how-to/geo-utilities.md
+++ b/docs/how-to/geo-utilities.md
@@ -1,0 +1,41 @@
+# Use the geo utilities
+
+Hyperion's geo support is split so that Haversine distance math stays in the
+**lite core** (`hyperion.domain.geo`), while Google Maps geocoding is an opt-in
+adapter behind the `[geo]` extra.
+
+```bash
+pip install 'hyperion-sdk[geo]'
+```
+
+## Geocode and reverse-geocode
+
+```python
+from hyperion.adapters.geocoder.google import GoogleMaps
+from hyperion.domain.geo import Location
+
+gmaps = GoogleMaps.from_config()  # reads HYPERION_GEO_GMAPS_API_KEY
+
+with gmaps:
+    location = gmaps.geocode("1600 Amphitheatre Parkway, Mountain View, CA")
+    print(f"Latitude: {location.latitude}, Longitude: {location.longitude}")
+
+    named_location = gmaps.reverse_geocode(location)
+    print(f"Address: {named_location.address}")
+    print(f"Country: {named_location.country}")
+```
+
+Use `GoogleMaps` as a context manager so its HTTP client is opened and closed
+cleanly.
+
+## Distance math without the extra
+
+`hyperion.domain.geo.Location` provides Haversine distance and lives in the
+lite core — no `[geo]` extra and no API key required for pure geometry.
+
+## See also
+
+- [Configure backends via environment](configure-via-environment.md) for
+  `HYPERION_GEO_GMAPS_API_KEY`.
+- API: [`hyperion.adapters.geocoder.google`](../reference/adapters/geocoder/google.md),
+  [`hyperion.domain.geo`](../reference/domain/geo.md).

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,0 +1,16 @@
+# How-to guides
+
+Task-oriented recipes. Each guide answers a single "how do I…?" and assumes
+you already know the basics (work through the [Tutorials](../tutorials/index.md)
+first if not).
+
+- [Install Hyperion and pick extras](install-and-extras.md)
+- [Configure backends via environment](configure-via-environment.md)
+- [Work with FeatureAssets](feature-assets.md)
+- [Work with PersistentStoreAssets](persistent-store-assets.md)
+- [Use a cached Catalog](cached-catalog.md)
+- [Fetch data with Asset Collections](asset-collections.md)
+- [Register and use schemas](schemas.md)
+- [Repartition data](repartition-data.md)
+- [Use the geo utilities](geo-utilities.md)
+- [Run a Source](run-a-source.md)

--- a/docs/how-to/install-and-extras.md
+++ b/docs/how-to/install-and-extras.md
@@ -1,0 +1,57 @@
+# Install Hyperion and pick extras
+
+## Install from PyPI
+
+```bash
+pip install hyperion-sdk
+# or
+poetry add hyperion-sdk
+```
+
+As of `1.0.0` the default install is a slim **lite core**. Heavy backends are
+opt-in extras — install only the ones you use.
+
+## Choose your extras
+
+| Extra | Enables |
+|---|---|
+| `hyperion-sdk[aws]` | DynamoDB cache/keyval, S3 storage/schema, SQS queue, AWS Secrets Manager |
+| `hyperion-sdk[data]` | pandera↔polars typing, asset schemas, `SpatialKMeans` |
+| `hyperion-sdk[catalog]` | avro-backed `Catalog` (works with local filesystem storage alone) |
+| `hyperion-sdk[geo]` | Google Maps geocoding (Haversine math stays in the lite core) |
+| `hyperion-sdk[snappy]` | snappy-compressed filesystem cache / DynamoDB keyval |
+| `hyperion-sdk[all]` | everything (parity with the pre-1.0 full install) |
+
+Combine extras as needed, e.g. a Catalog on S3:
+
+```bash
+pip install 'hyperion-sdk[catalog,aws]'
+```
+
+The catalog examples elsewhere in these docs need at least
+`pip install 'hyperion-sdk[catalog]'`; add `[aws]` if you store assets on S3.
+
+## Pin your version
+
+Hyperion follows [Semantic Versioning](https://semver.org/), so pin to a
+compatible range to avoid breaking changes:
+
+```bash
+poetry add 'hyperion-sdk[catalog]@^1.0.0'
+```
+
+## Install from source
+
+Hyperion uses [Poetry](https://python-poetry.org/):
+
+```bash
+git clone https://github.com/tomasvotava/hyperion.git
+cd hyperion
+poetry install
+```
+
+!!! note "Upgrading from a pre-1.0 release?"
+    Import paths moved and the `Catalog` constructor changed. Follow
+    [Migrating from pre-1.0](../reference/migration-pre-1.0.md) before
+    upgrading. The rationale for the lite-core split is in
+    [Lite core and extras](../explanation/extras-and-lite-core.md).

--- a/docs/how-to/persistent-store-assets.md
+++ b/docs/how-to/persistent-store-assets.md
@@ -1,0 +1,33 @@
+# Work with PersistentStoreAssets
+
+A `PersistentStoreAsset` represents persistent data **without** time
+partitioning — reference data, lookup tables, configuration, master data.
+
+## Store and retrieve
+
+```python
+from hyperion.catalog.catalog import Catalog
+from hyperion.domain.assets import PersistentStoreAsset
+
+catalog = Catalog.from_config()
+
+asset = PersistentStoreAsset(name="product_catalog", schema_version=1)
+
+catalog.store_asset(asset, [
+    {"id": "P001", "name": "Product 1", "category": "Electronics"},
+    {"id": "P002", "name": "Product 2", "category": "Clothing"},
+])
+
+for product in catalog.retrieve_asset(asset):
+    print(product)
+```
+
+Because there is no date partition, storing the same asset name + schema
+version replaces the previous payload — that is the intended "current state"
+semantics for reference data.
+
+## See also
+
+- [Register and use schemas](schemas.md) — persistent assets are validated
+  against `persistent_store/{name}.v{version}.avro.json`.
+- [Assets and the Catalog](../explanation/assets-and-catalog.md).

--- a/docs/how-to/repartition-data.md
+++ b/docs/how-to/repartition-data.md
@@ -1,0 +1,42 @@
+# Repartition data
+
+Use `Catalog.repartition` to change the partition granularity of a stored
+asset — for example, re-bucket day-partitioned data into hourly partitions
+keyed off a timestamp field.
+
+```python
+import asyncio
+from datetime import datetime, timezone
+
+from hyperion.catalog.catalog import Catalog
+from hyperion.domain.assets import DataLakeAsset
+from hyperion.dateutils import TimeResolutionUnit
+
+
+async def repartition_data():
+    catalog = Catalog.from_config()
+
+    asset = DataLakeAsset(
+        name="web_logs",
+        date=datetime.now(timezone.utc),
+        schema_version=1,
+    )
+
+    await catalog.repartition(
+        asset,
+        granularity=TimeResolutionUnit("h"),  # repartition by hour
+        date_attribute="timestamp",           # field to derive the partition from
+    )
+
+
+asyncio.run(repartition_data())
+```
+
+`repartition` is asynchronous — run it inside an event loop (`asyncio.run`, or
+`await` it from existing async code).
+
+## See also
+
+- [Work with FeatureAssets](feature-assets.md) for time-resolution concepts.
+- API: [`hyperion.catalog.catalog`](../reference/catalog/catalog.md),
+  [`hyperion.dateutils`](../reference/dateutils.md).

--- a/docs/how-to/run-a-source.md
+++ b/docs/how-to/run-a-source.md
@@ -1,0 +1,61 @@
+# Run a Source
+
+Once you have written a `Source` (see the
+[custom Source tutorial](../tutorials/custom-source.md)), there are three ways
+to run it.
+
+## In-process
+
+Drive the source directly with a catalog:
+
+```python
+import asyncio
+from hyperion.catalog.catalog import Catalog
+
+asyncio.run(MyCustomSource._run(Catalog.from_config()))
+```
+
+## On AWS Lambda
+
+Let the base class handle the Lambda event:
+
+```python
+def lambda_handler(event, context):
+    MyCustomSource.handle_aws_lambda_event(event, context)
+```
+
+Schedule the Lambda (e.g. EventBridge) for periodic extraction; pass backfill
+parameters through the event payload.
+
+## As a CLI ("Argo Workflow" mode)
+
+`SourceRunner` builds a click CLI over one or more sources:
+
+```python
+from hyperion.sources.cli import SourceRunner
+from my_sources import FirstSource, SecondSource
+
+if __name__ == "__main__":
+    SourceRunner(FirstSource, SecondSource).cli()
+```
+
+```bash
+python running_sources.py first-source run \
+    --start-date 2025-01-01 \
+    --end-date 2025-02-01 \
+    --params '{"foo": "bar"}' \
+    --queue-file /argo/output/messages.json \
+    --queue-overwrite
+```
+
+The command name is the `source` attribute of each `Source` subclass. All
+options are optional — see the
+[custom Source tutorial](../tutorials/custom-source.md#4-expose-a-cli-argo-workflow-mode)
+for the full option table.
+
+## See also
+
+- API: [`hyperion.sources.base`](../reference/sources/base.md),
+  [`hyperion.sources.cli`](../reference/sources/cli.md).
+- [Configure backends via environment](configure-via-environment.md) for
+  `HYPERION_SOURCE_PARAMS` and queue settings.

--- a/docs/how-to/schemas.md
+++ b/docs/how-to/schemas.md
@@ -1,0 +1,61 @@
+# Register and use schemas
+
+Every asset is validated against an Avro schema during storage and retrieval.
+Schemas are named with the pattern:
+
+```
+{asset_type}/{asset_name}.v{version}.avro.json
+```
+
+where `asset_type` is `data_lake`, `feature`, or `persistent_store`. If a
+schema is missing, `store_asset`/`retrieve_asset` raises until you provide it.
+
+## Define and register a schema
+
+```python
+import json
+from pathlib import Path
+
+schema = {
+    "type": "record",
+    "name": "CustomerData",
+    "fields": [
+        {"name": "id", "type": "int"},
+        {"name": "name", "type": "string"},
+        {"name": "timestamp", "type": {"type": "long", "logicalType": "timestamp-millis"}},
+    ],
+}
+
+# Local schema store
+schema_path = Path("schemas/data_lake/customer_data.v1.avro.json")
+schema_path.parent.mkdir(parents=True, exist_ok=True)
+schema_path.write_text(json.dumps(schema))
+```
+
+## Register a schema on S3
+
+When using `S3SchemaStore` (the `[aws]` extra), upload the schema under the
+same key layout:
+
+```python
+import boto3, json
+
+boto3.client("s3").put_object(
+    Bucket="my-schema-bucket",
+    Key="data_lake/customer_data.v1.avro.json",
+    Body=json.dumps(schema),
+)
+```
+
+## Schema evolution
+
+Assets carry a `schema_version`. To evolve a schema, register a new file with
+an incremented version (`...v2.avro.json`) and bump `schema_version` on the
+asset; old partitions keep resolving against their original version.
+
+## See also
+
+- [Your first DataLakeAsset](../tutorials/first-datalake-asset.md) walks
+  through a schema end to end.
+- API: [`hyperion.adapters.schema_registry.local`](../reference/adapters/schema_registry/local.md)
+  and [`...schema_registry.s3`](../reference/adapters/schema_registry/s3.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,68 @@
+# Hyperion
+
+A headless ETL / ELT / data pipeline and integration SDK for Python.
+
+[![pre-commit](https://github.com/tomasvotava/hyperion/actions/workflows/pre-commit.yml/badge.svg?branch=master)](https://github.com/tomasvotava/hyperion/actions/workflows/pre-commit.yml)
+[![pytest](https://github.com/tomasvotava/hyperion/actions/workflows/pytest.yml/badge.svg?branch=master)](https://github.com/tomasvotava/hyperion/actions/workflows/pytest.yml)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/hyperion-sdk)
+![GitHub Release](https://img.shields.io/github/v/release/tomasvotava/hyperion)
+
+Hyperion organises data assets (a *data catalog*), validates them against Avro
+schemas, abstracts the storage/queue/cache/secrets backends behind ports and
+adapters, and gives you a framework for writing data **sources**. It runs the
+same code on a laptop (local filesystem) or on AWS (S3/DynamoDB/SQS) — the
+wiring is configuration, not code.
+
+## Features
+
+- **Data Catalog** — manage and organise data assets across backends.
+- **Schema management** — validate and store Avro schema definitions per asset.
+- **Ports & adapters** — swap S3/DynamoDB/SQS for local filesystem with config.
+- **Source framework** — define sources that extract data into the catalog.
+- **Caching** — in-memory, local file, and DynamoDB caching.
+- **Async processing** — utilities for async operations and task queues.
+- **CLI runner** — run sources standalone or in "Argo Workflow" mode.
+- **Geo utilities** — Haversine math in the lite core; Google Maps via `[geo]`.
+- **Asset collections** — a typed, declarative interface over groups of assets.
+
+## Install
+
+```bash
+pip install 'hyperion-sdk[catalog]'
+```
+
+The default install is a slim **lite core**; heavy backends are opt-in extras.
+See [Install Hyperion and pick extras](how-to/install-and-extras.md).
+
+```python
+from hyperion.catalog.catalog import Catalog
+from hyperion.domain.assets import DataLakeAsset
+from datetime import datetime, timezone
+
+catalog = Catalog.from_config()
+asset = DataLakeAsset(name="customer_data", date=datetime.now(timezone.utc), schema_version=1)
+catalog.store_asset(asset, [{"id": 1, "name": "Customer 1"}])
+```
+
+## Documentation
+
+This site follows the [Diataxis](https://diataxis.fr/) structure:
+
+- **[Tutorials](tutorials/index.md)** — learning-oriented walkthroughs. Start
+  with [your first DataLakeAsset](tutorials/first-datalake-asset.md).
+- **[How-to guides](how-to/index.md)** — task-oriented recipes (extras,
+  configuration, feature assets, caching, sources, geo, …).
+- **[Reference](reference/migration-pre-1.0.md)** — the auto-generated API
+  reference and the pre-1.0 migration guide.
+- **[Explanation](explanation/index.md)** — the architecture, the ports/adapters
+  design, and the lite-core + extras model.
+
+!!! note "Upgrading from a pre-1.0 release?"
+    Import paths moved and the `Catalog` constructor changed. See
+    [Migrating from pre-1.0](reference/migration-pre-1.0.md).
+
+## Project
+
+- Source: <https://github.com/tomasvotava/hyperion>
+- Changelog: <https://github.com/tomasvotava/hyperion/blob/master/CHANGELOG.md>
+- Licensed under the MIT License.

--- a/docs/reference/migration-pre-1.0.md
+++ b/docs/reference/migration-pre-1.0.md
@@ -1,0 +1,84 @@
+# Migrating from pre-1.0
+
+`1.0.0` finishes the ports/adapters (DDD) layout. It is a **structural**
+refactor — no features added, no behaviour changed (one bug fixed). Every
+relocated symbol stays importable from its old path for the whole 1.x line
+behind a `DeprecationWarning`; the old paths are removed in 2.0. The single
+non-additive break is the `Catalog` constructor, mitigated by
+`Catalog.from_config()`.
+
+!!! info "The canonical migration guide lives in the changelog"
+    The authoritative, always-current upgrade guide is pinned at the top of
+    [`CHANGELOG.md`](https://github.com/tomasvotava/hyperion/blob/master/CHANGELOG.md).
+    It is regenerated on every release, so it is the single source of truth.
+    This page summarises it; follow the changelog for the exact symbol table.
+
+## What changed, in three parts
+
+### 1. Packaging: lite core + opt-in extras
+
+`pip install hyperion-sdk` is now a slim lite core. Heavy backends are opt-in
+extras. A consumer that used `Catalog`/avro now needs `hyperion-sdk[catalog]`;
+DynamoDB/S3/SQS needs `[aws]`; the pandera/polars helpers need `[data]`; Google
+geocoding needs `[geo]`; `[all]` reproduces the pre-1.0 install exactly. See
+[Install Hyperion and pick extras](../how-to/install-and-extras.md) and the
+rationale in [Lite core and extras](../explanation/extras-and-lite-core.md).
+
+### 2. Import paths moved (deprecated, removed in 2.0)
+
+58 symbols across 12 modules moved from `hyperion.infrastructure.*`,
+`hyperion.entities.*`, `hyperion.catalog`/`hyperion.catalog.schema`, and the
+pandera/polars parts of `hyperion.typeutils` into the new
+`hyperion.ports.*` / `hyperion.adapters.*` / `hyperion.domain.*` /
+`hyperion.data.*` layout. **Only the import module changes — symbol names are
+unchanged.** Old paths keep working through all of 1.x but emit a
+`DeprecationWarning` naming the new path. Run your test suite with deprecation
+warnings visible to surface every call site mechanically, and consult the
+[changelog table](https://github.com/tomasvotava/hyperion/blob/master/CHANGELOG.md)
+for the exact old→new mapping.
+
+The lite core (`hyperion.log`, `hyperion.config`, `hyperion.dateutils`,
+`hyperion.asyncutils`) did **not** move, and `hyperion.typeutils` keeps its
+stdlib helpers.
+
+### 3. The `Catalog` constructor (the one hard break)
+
+`Catalog.__init__` is the only non-additive break — no compat shim. The old
+bucket/prefix keyword arguments, `StoreBucketConfig`, `Catalog.s3_client`, and
+`get_store_config()` are removed.
+
+```python
+from hyperion.ports.storage import StoragePort
+
+Catalog(
+    storage=...,        # a StoragePort, or Mapping[AssetType, StoragePort]
+    queue=None,
+    cache=None,
+    schema_store=None,
+    serializer=None,    # AvroSerializer; a fresh one by default
+)
+```
+
+A single `StoragePort` serves every asset type; pass a mapping keyed by
+`"data_lake"` / `"feature"` / `"persistent_store"` to route each type to a
+different backend.
+
+**Escape hatch:** `Catalog.from_config()` is unchanged in name and intent — it
+rebuilds the per-bucket S3 layout from the environment. Consumers that only ever
+used `Catalog.from_config()` need no constructor change.
+
+**Bug fixed (behaviour change, deliberate):** pre-1.0 `Catalog.from_config()`
+wired the feature store with the *data-lake* prefix. It now correctly uses the
+feature-store prefix. Where the two prefixes differ, feature-store asset keys
+resolve to a different (correct) path after upgrading — review any tooling that
+depended on the old, wrong path.
+
+## Migration checklist
+
+1. **Relax the version pin** to admit `1.x` (e.g. widen `>=0.15.0,<1`).
+2. **Request the extras you use** — the default install is now lite.
+3. **Rewrite moved imports** using the changelog table (names unchanged).
+4. **Check direct `Catalog(...)` construction** — switch to
+   `Catalog.from_config()` or the new `storage=` constructor.
+5. **Account for the `from_config()` prefix fix** if your data-lake and
+   feature-store prefixes differ.

--- a/docs/tutorials/custom-source.md
+++ b/docs/tutorials/custom-source.md
@@ -1,0 +1,99 @@
+# Building a custom Source
+
+A **Source** extracts data from an external system and yields assets into the
+catalog. In this tutorial you will write one, run it in-process, and then
+expose it as a command-line tool.
+
+This builds on [Your first DataLakeAsset](first-datalake-asset.md) — you should
+already have a working local catalog (or `Catalog.from_config()` configured).
+
+## 1. Write the Source
+
+Subclass `Source`, give it a `source` name, and implement the async `run`
+method as an async generator yielding `SourceAsset` objects:
+
+```python
+import asyncio
+from datetime import datetime, timezone
+from typing import AsyncIterator
+
+from hyperion.catalog.catalog import Catalog
+from hyperion.domain.assets import DataLakeAsset
+from hyperion.sources.base import Source, SourceAsset
+
+
+class MyCustomSource(Source):
+    source = "my-custom-source"
+
+    async def run(self, start_date=None, end_date=None) -> AsyncIterator[SourceAsset]:
+        # Where you would call an API, read a file, query a DB, ...
+        data = [
+            {"id": 1, "name": "Item 1", "timestamp": datetime.now(timezone.utc)},
+            {"id": 2, "name": "Item 2", "timestamp": datetime.now(timezone.utc)},
+        ]
+
+        asset = DataLakeAsset(name="my-custom-data", date=datetime.now(timezone.utc))
+        yield SourceAsset(asset=asset, data=data)
+```
+
+## 2. Run it in-process
+
+Drive the source with a catalog directly:
+
+```python
+if __name__ == "__main__":
+    asyncio.run(MyCustomSource._run(Catalog.from_config()))
+```
+
+## 3. Run it on AWS Lambda
+
+The base class can handle a Lambda event for you:
+
+```python
+def lambda_handler(event, context):
+    MyCustomSource.handle_aws_lambda_event(event, context)
+```
+
+## 4. Expose a CLI ("Argo Workflow" mode)
+
+`SourceRunner` generates a click-based CLI for one or more sources. Create
+`running_sources.py`:
+
+```python
+from hyperion.sources.cli import SourceRunner
+from my_sources import FirstSource, SecondSource
+
+if __name__ == "__main__":
+    SourceRunner(FirstSource, SecondSource).cli()
+```
+
+Invoke a source from the command line — the command name comes from each
+class's `source` attribute:
+
+```bash
+python running_sources.py my-custom-source run \
+    --start-date 2025-01-01 \
+    --end-date 2025-02-01 \
+    --params '{"foo": "bar"}' \
+    --queue-file /argo/output/messages.json \
+    --queue-overwrite
+```
+
+All generated options are optional:
+
+| Option | Meaning |
+|---|---|
+| `--start-date` | start date passed to the source |
+| `--end-date` | end date passed to the source |
+| `--params` | JSON string of source-specific params |
+| `--params-from` | path to a JSON file of source-specific params |
+| `--queue-file` | output file for queued messages |
+| `--queue-overwrite` | overwrite the queue file if it exists |
+
+## What you learned
+
+You implemented the `Source` contract, ran it three ways (in-process, Lambda,
+CLI), and saw how `SourceRunner` turns sources into operable tools. See the
+[Source framework explanation](../explanation/architecture.md) for how sources
+fit the overall design, and
+[Run a Source](../how-to/run-a-source.md) for deployment recipes.

--- a/docs/tutorials/first-datalake-asset.md
+++ b/docs/tutorials/first-datalake-asset.md
@@ -1,0 +1,103 @@
+# Your first DataLakeAsset
+
+By the end of this tutorial you will have stored a data asset in a local
+Hyperion catalog and read it back — with no AWS account and no environment
+configuration. You will touch the four core pieces: a **schema**, a
+**storage** adapter, a **schema store** adapter, and the **`Catalog`**.
+
+## 1. Install
+
+The catalog serialises assets as Avro, so install the `[catalog]` extra:
+
+```bash
+pip install 'hyperion-sdk[catalog]'
+```
+
+## 2. Lay out local directories
+
+Hyperion can run entirely on local disk. Create two directories — one for the
+data lake, one for schemas:
+
+```bash
+mkdir -p /tmp/hyperion/lake /tmp/hyperion/schemas/data_lake
+```
+
+## 3. Define a schema
+
+Every asset is validated against an Avro schema. Schemas are named
+`{asset_type}/{asset_name}.v{version}.avro.json`. Create
+`/tmp/hyperion/schemas/data_lake/customer_data.v1.avro.json`:
+
+```json
+{
+  "type": "record",
+  "name": "CustomerData",
+  "fields": [
+    { "name": "id", "type": "int" },
+    { "name": "name", "type": "string" }
+  ]
+}
+```
+
+## 4. Build a local Catalog
+
+`Catalog.from_config()` reads the environment and wires S3. For this tutorial
+construct the `Catalog` explicitly with the filesystem adapters instead:
+
+```python
+from pathlib import Path
+
+from hyperion.catalog.catalog import Catalog
+from hyperion.adapters.storage.filesystem import FilesystemStorage
+from hyperion.adapters.schema_registry.local import LocalSchemaStore
+
+catalog = Catalog(
+    storage=FilesystemStorage("/tmp/hyperion/lake"),
+    schema_store=LocalSchemaStore(Path("/tmp/hyperion/schemas")),
+)
+```
+
+## 5. Store an asset
+
+A `DataLakeAsset` is identified by a name, a date partition, and a schema
+version. Store some records against the schema you defined:
+
+```python
+from datetime import datetime, timezone
+from hyperion.domain.assets import DataLakeAsset
+
+asset = DataLakeAsset(
+    name="customer_data",
+    date=datetime.now(timezone.utc),
+    schema_version=1,
+)
+
+catalog.store_asset(asset, [
+    {"id": 1, "name": "Customer 1"},
+    {"id": 2, "name": "Customer 2"},
+])
+```
+
+If the schema file is missing or the records don't match it, `store_asset`
+raises — that is the schema validation doing its job.
+
+## 6. Read it back
+
+```python
+for record in catalog.retrieve_asset(asset):
+    print(record)
+# {'id': 1, 'name': 'Customer 1'}
+# {'id': 2, 'name': 'Customer 2'}
+```
+
+## What you learned
+
+You wired a `Catalog` from a storage adapter and a schema store, validated
+data against an Avro schema, and round-tripped an asset — all locally. The
+same code runs on AWS by swapping the adapters (or using
+`Catalog.from_config()`); see
+[Configure backends via environment](../how-to/configure-via-environment.md).
+
+Next: [build a custom Source](custom-source.md) to populate the catalog
+automatically, or read
+[Assets and the Catalog](../explanation/assets-and-catalog.md) for the concepts.

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,0 +1,14 @@
+# Tutorials
+
+Learning-oriented walkthroughs. Each tutorial is a guided, end-to-end path you
+can follow start to finish — it teaches by doing, on a local filesystem so you
+need no AWS account.
+
+- **[Your first DataLakeAsset](first-datalake-asset.md)** — install Hyperion,
+  define a schema, build a local `Catalog`, store an asset, and read it back.
+- **[Building a custom Source](custom-source.md)** — write a `Source` that
+  extracts data into the catalog and run it from the command line.
+
+Once you are comfortable with the concepts, the
+[How-to guides](../how-to/index.md) cover specific tasks, and the
+[Explanation](../explanation/index.md) section covers the design.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,6 @@ site_description: A headless ETL / ELT / data pipeline and integration SDK for P
 site_url: https://tomasvotava.github.io/hyperion/
 repo_url: https://github.com/tomasvotava/hyperion
 repo_name: tomasvotava/hyperion
-edit_uri: edit/master/docs/
 copyright: Copyright &copy; Tomas Votava
 
 theme:
@@ -17,7 +16,6 @@ theme:
     - search.suggest
     - search.highlight
     - content.code.copy
-    - content.action.edit
   palette:
     - scheme: default
       primary: indigo

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,112 @@
+site_name: Hyperion
+site_description: A headless ETL / ELT / data pipeline and integration SDK for Python.
+site_url: https://tomasvotava.github.io/hyperion/
+repo_url: https://github.com/tomasvotava/hyperion
+repo_name: tomasvotava/hyperion
+edit_uri: edit/master/docs/
+copyright: Copyright &copy; Tomas Votava
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.tracking
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.action.edit
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true
+  - pymdownx.superfences
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.snippets:
+      base_path:
+        - .
+
+plugins:
+  - search
+  - gen-files:
+      scripts:
+        - docs/gen_ref_pages.py
+  - literate-nav:
+      nav_file: SUMMARY.md
+  - section-index
+  - mkdocstrings:
+      handlers:
+        python:
+          paths:
+            - .
+          options:
+            docstring_style: google
+            docstring_section_style: table
+            show_source: true
+            show_root_heading: true
+            show_root_full_path: true
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            members_order: source
+            separate_signature: true
+            signature_crossrefs: true
+            merge_init_into_class: true
+            filters:
+              - "!^_"
+
+exclude_docs: |
+  ddd-refactor-plan.md
+  gen_ref_pages.py
+
+nav:
+  - Home: index.md
+  - Tutorials:
+      - tutorials/index.md
+      - First DataLakeAsset: tutorials/first-datalake-asset.md
+      - Building a custom Source: tutorials/custom-source.md
+  - How-to guides:
+      - how-to/index.md
+      - Install Hyperion and pick extras: how-to/install-and-extras.md
+      - Configure backends via environment: how-to/configure-via-environment.md
+      - Work with FeatureAssets: how-to/feature-assets.md
+      - Work with PersistentStoreAssets: how-to/persistent-store-assets.md
+      - Use a cached Catalog: how-to/cached-catalog.md
+      - Fetch data with Asset Collections: how-to/asset-collections.md
+      - Register and use schemas: how-to/schemas.md
+      - Repartition data: how-to/repartition-data.md
+      - Use the geo utilities: how-to/geo-utilities.md
+      - Run a Source: how-to/run-a-source.md
+  - Reference: reference/
+  - Explanation:
+      - explanation/index.md
+      - Architecture: explanation/architecture.md
+      - Assets and the Catalog: explanation/assets-and-catalog.md
+      - Ports and adapters: explanation/ports-and-adapters.md
+      - Lite core and extras: explanation/extras-and-lite-core.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/tomasvotava/hyperion

--- a/poetry.lock
+++ b/poetry.lock
@@ -412,6 +412,40 @@ botocore = ">=1.11.3"
 wrapt = "*"
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+description = "Internationalization utilities"
+optional = false
+python-versions = ">=3.8"
+groups = ["docs"]
+files = [
+    {file = "babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35"},
+    {file = "babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d"},
+]
+
+[package.extras]
+dev = ["backports.zoneinfo ; python_version < \"3.9\"", "freezegun (>=1.0,<2.0)", "jinja2 (>=3.0)", "pytest (>=6.0)", "pytest-cov", "pytz", "setuptools", "tzdata ; sys_platform == \"win32\""]
+
+[[package]]
+name = "backrefs"
+version = "7.0"
+description = "A wrapper around re and regex that adds additional back references."
+optional = false
+python-versions = ">=3.10"
+groups = ["docs"]
+files = [
+    {file = "backrefs-7.0-py310-none-any.whl", hash = "sha256:b57cd227ea556b0aed3dc9b8da4628db4eabc0402c6d7fcfc69283a93955f7e9"},
+    {file = "backrefs-7.0-py311-none-any.whl", hash = "sha256:a0fa7360c63509e9e077e174ef4e6d3c21c8db94189b9d957289ae6d794b9475"},
+    {file = "backrefs-7.0-py312-none-any.whl", hash = "sha256:ca42ce6a49ace3d75684dfa9937f3373902a63284ecb385ce36d15e5dcb41c12"},
+    {file = "backrefs-7.0-py313-none-any.whl", hash = "sha256:f2c52955d631b9e1ac4cd56209f0a3a946d592b98e7790e77699339ae01c102a"},
+    {file = "backrefs-7.0-py314-none-any.whl", hash = "sha256:a6448b28180e3ca01134c9cf09dcebafad8531072e09903c5451748a05f24bc9"},
+    {file = "backrefs-7.0.tar.gz", hash = "sha256:4989bb9e1e99eb23647c7160ed51fb21d0b41b5d200f2d3017da41e023097e82"},
+]
+
+[package.extras]
+extras = ["regex"]
+
+[[package]]
 name = "blinker"
 version = "1.9.0"
 description = "Fast, simple object-to-object and broadcast signaling"
@@ -949,7 +983,7 @@ version = "2026.4.22"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a"},
     {file = "certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580"},
@@ -1086,7 +1120,7 @@ version = "3.4.7"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d"},
     {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8"},
@@ -1226,7 +1260,7 @@ version = "8.4.0"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "click-8.4.0-py3-none-any.whl", hash = "sha256:40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81"},
     {file = "click-8.4.0.tar.gz", hash = "sha256:638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973"},
@@ -1241,7 +1275,7 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main", "dev"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -1920,6 +1954,24 @@ files = [
 ]
 
 [[package]]
+name = "ghp-import"
+version = "2.1.0"
+description = "Copy your docs directly to the gh-pages branch."
+optional = false
+python-versions = "*"
+groups = ["docs"]
+files = [
+    {file = "ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343"},
+    {file = "ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619"},
+]
+
+[package.dependencies]
+python-dateutil = ">=2.8.1"
+
+[package.extras]
+dev = ["flake8", "markdown", "twine", "wheel"]
+
+[[package]]
 name = "googlemaps"
 version = "4.10.0"
 description = "Python client library for Google Maps Platform"
@@ -1945,6 +1997,21 @@ files = [
     {file = "graphql_core-3.2.8-py3-none-any.whl", hash = "sha256:cbee07bee1b3ed5e531723685369039f32ff815ef60166686e0162f540f1520c"},
     {file = "graphql_core-3.2.8.tar.gz", hash = "sha256:015457da5d996c924ddf57a43f4e959b0b94fb695b85ed4c29446e508ed65cf3"},
 ]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
+optional = false
+python-versions = ">=3.10"
+groups = ["docs"]
+files = [
+    {file = "griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1"},
+    {file = "griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e"},
+]
+
+[package.extras]
+pypi = ["pip (>=24.0)", "platformdirs (>=4.2)", "wheel (>=0.42)"]
 
 [[package]]
 name = "grimp"
@@ -2141,7 +2208,7 @@ version = "3.15"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"},
     {file = "idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc"},
@@ -2201,7 +2268,7 @@ version = "3.1.6"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["dev", "docs"]
 files = [
     {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
     {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
@@ -2515,6 +2582,22 @@ win32-setctime = {version = ">=1.0.0", markers = "sys_platform == \"win32\""}
 dev = ["Sphinx (==8.1.3) ; python_version >= \"3.11\"", "build (==1.2.2) ; python_version >= \"3.11\"", "colorama (==0.4.5) ; python_version < \"3.8\"", "colorama (==0.4.6) ; python_version >= \"3.8\"", "exceptiongroup (==1.1.3) ; python_version >= \"3.7\" and python_version < \"3.11\"", "freezegun (==1.1.0) ; python_version < \"3.8\"", "freezegun (==1.5.0) ; python_version >= \"3.8\"", "mypy (==0.910) ; python_version < \"3.6\"", "mypy (==0.971) ; python_version == \"3.6\"", "mypy (==1.13.0) ; python_version >= \"3.8\"", "mypy (==1.4.1) ; python_version == \"3.7\"", "myst-parser (==4.0.0) ; python_version >= \"3.11\"", "pre-commit (==4.0.1) ; python_version >= \"3.9\"", "pytest (==6.1.2) ; python_version < \"3.8\"", "pytest (==8.3.2) ; python_version >= \"3.8\"", "pytest-cov (==2.12.1) ; python_version < \"3.8\"", "pytest-cov (==5.0.0) ; python_version == \"3.8\"", "pytest-cov (==6.0.0) ; python_version >= \"3.9\"", "pytest-mypy-plugins (==1.9.3) ; python_version >= \"3.6\" and python_version < \"3.8\"", "pytest-mypy-plugins (==3.1.0) ; python_version >= \"3.8\"", "sphinx-rtd-theme (==3.0.2) ; python_version >= \"3.11\"", "tox (==3.27.1) ; python_version < \"3.8\"", "tox (==4.23.2) ; python_version >= \"3.8\"", "twine (==6.0.1) ; python_version >= \"3.11\""]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+description = "Python implementation of John Gruber's Markdown."
+optional = false
+python-versions = ">=3.10"
+groups = ["docs"]
+files = [
+    {file = "markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36"},
+    {file = "markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950"},
+]
+
+[package.extras]
+docs = ["mdx_gh_links (>=0.2)", "mkdocs (>=1.6)", "mkdocs-gen-files", "mkdocs-literate-nav", "mkdocs-nature (>=0.6)", "mkdocs-section-index", "mkdocstrings[python] (>=0.28.3)"]
+testing = ["coverage", "pyyaml"]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
@@ -2544,7 +2627,7 @@ version = "3.0.3"
 description = "Safely add untrusted strings to HTML/XML markup."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["dev", "docs"]
 files = [
     {file = "markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559"},
     {file = "markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419"},
@@ -2648,6 +2731,215 @@ files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
 ]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+description = "A deep merge function for 🐍."
+optional = false
+python-versions = ">=3.6"
+groups = ["docs"]
+files = [
+    {file = "mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307"},
+    {file = "mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8"},
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+description = "Project documentation with Markdown."
+optional = false
+python-versions = ">=3.8"
+groups = ["docs"]
+files = [
+    {file = "mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e"},
+    {file = "mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2"},
+]
+
+[package.dependencies]
+click = ">=7.0"
+colorama = {version = ">=0.4", markers = "platform_system == \"Windows\""}
+ghp-import = ">=1.0"
+jinja2 = ">=2.11.1"
+markdown = ">=3.3.6"
+markupsafe = ">=2.0.1"
+mergedeep = ">=1.3.4"
+mkdocs-get-deps = ">=0.2.0"
+packaging = ">=20.5"
+pathspec = ">=0.11.1"
+pyyaml = ">=5.1"
+pyyaml-env-tag = ">=0.1"
+watchdog = ">=2.0"
+
+[package.extras]
+i18n = ["babel (>=2.9.0)"]
+min-versions = ["babel (==2.9.0)", "click (==7.0)", "colorama (==0.4) ; platform_system == \"Windows\"", "ghp-import (==1.0)", "importlib-metadata (==4.4) ; python_version < \"3.10\"", "jinja2 (==2.11.1)", "markdown (==3.3.6)", "markupsafe (==2.0.1)", "mergedeep (==1.3.4)", "mkdocs-get-deps (==0.2.0)", "packaging (==20.5)", "pathspec (==0.11.1)", "pyyaml (==5.1)", "pyyaml-env-tag (==0.1)", "watchdog (==2.0)"]
+
+[[package]]
+name = "mkdocs-autorefs"
+version = "1.4.4"
+description = "Automatically link across pages in MkDocs."
+optional = false
+python-versions = ">=3.9"
+groups = ["docs"]
+files = [
+    {file = "mkdocs_autorefs-1.4.4-py3-none-any.whl", hash = "sha256:834ef5408d827071ad1bc69e0f39704fa34c7fc05bc8e1c72b227dfdc5c76089"},
+    {file = "mkdocs_autorefs-1.4.4.tar.gz", hash = "sha256:d54a284f27a7346b9c38f1f852177940c222da508e66edc816a0fa55fc6da197"},
+]
+
+[package.dependencies]
+Markdown = ">=3.3"
+markupsafe = ">=2.0.1"
+mkdocs = ">=1.1"
+
+[[package]]
+name = "mkdocs-gen-files"
+version = "0.5.0"
+description = "MkDocs plugin to programmatically generate documentation pages during the build"
+optional = false
+python-versions = ">=3.7"
+groups = ["docs"]
+files = [
+    {file = "mkdocs_gen_files-0.5.0-py3-none-any.whl", hash = "sha256:7ac060096f3f40bd19039e7277dd3050be9a453c8ac578645844d4d91d7978ea"},
+    {file = "mkdocs_gen_files-0.5.0.tar.gz", hash = "sha256:4c7cf256b5d67062a788f6b1d035e157fc1a9498c2399be9af5257d4ff4d19bc"},
+]
+
+[package.dependencies]
+mkdocs = ">=1.0.3"
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+description = "An extra command for MkDocs that infers required PyPI packages from `plugins` in mkdocs.yml"
+optional = false
+python-versions = ">=3.9"
+groups = ["docs"]
+files = [
+    {file = "mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650"},
+    {file = "mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1"},
+]
+
+[package.dependencies]
+mergedeep = ">=1.3.4"
+platformdirs = ">=2.2.0"
+pyyaml = ">=5.1"
+
+[[package]]
+name = "mkdocs-literate-nav"
+version = "0.6.3"
+description = "MkDocs plugin to specify the navigation in Markdown instead of YAML"
+optional = false
+python-versions = ">=3.9"
+groups = ["docs"]
+files = [
+    {file = "mkdocs_literate_nav-0.6.3-py3-none-any.whl", hash = "sha256:2c421561280fa9184f88cbf399bebbd4cc17ee507e978a31ce11fd6f3aabf233"},
+    {file = "mkdocs_literate_nav-0.6.3.tar.gz", hash = "sha256:edbaca22343f861fe4e34aac47d55a0c9955c640dbf02eea99fe631e914cf9ee"},
+]
+
+[package.dependencies]
+mkdocs = ">=1.4.1,<=1.6.1"
+properdocs = ">=1.6.5"
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.6"
+description = "Documentation that simply works"
+optional = false
+python-versions = ">=3.8"
+groups = ["docs"]
+files = [
+    {file = "mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba"},
+    {file = "mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69"},
+]
+
+[package.dependencies]
+babel = ">=2.10"
+backrefs = ">=5.7.post1"
+colorama = ">=0.4"
+jinja2 = ">=3.1"
+markdown = ">=3.2"
+mkdocs = ">=1.6,<2"
+mkdocs-material-extensions = ">=1.3"
+paginate = ">=0.5"
+pygments = ">=2.16"
+pymdown-extensions = ">=10.2"
+requests = ">=2.30"
+
+[package.extras]
+git = ["mkdocs-git-committers-plugin-2 (>=1.1)", "mkdocs-git-revision-date-localized-plugin (>=1.2.4)"]
+imaging = ["cairosvg (>=2.6)", "pillow (>=10.2)"]
+recommended = ["mkdocs-minify-plugin (>=0.7)", "mkdocs-redirects (>=1.2)", "mkdocs-rss-plugin (>=1.6)"]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+description = "Extension pack for Python Markdown and MkDocs Material."
+optional = false
+python-versions = ">=3.8"
+groups = ["docs"]
+files = [
+    {file = "mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31"},
+    {file = "mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443"},
+]
+
+[[package]]
+name = "mkdocs-section-index"
+version = "0.3.12"
+description = "MkDocs plugin to allow clickable sections that lead to an index page"
+optional = false
+python-versions = ">=3.10"
+groups = ["docs"]
+files = [
+    {file = "mkdocs_section_index-0.3.12-py3-none-any.whl", hash = "sha256:a1100039546beb4ebef63ce6fc91f3195fb9c0c3763105d4d3d7cd31e0a046eb"},
+    {file = "mkdocs_section_index-0.3.12.tar.gz", hash = "sha256:285635bf86c643b0fc7a343053d7a818049817bff4408f52b80c4367bd5e7268"},
+]
+
+[package.dependencies]
+mkdocs = ">=1.2,<=1.6.1"
+properdocs = ">=1.6.5"
+
+[[package]]
+name = "mkdocstrings"
+version = "0.30.1"
+description = "Automatic documentation from sources, for MkDocs."
+optional = false
+python-versions = ">=3.9"
+groups = ["docs"]
+files = [
+    {file = "mkdocstrings-0.30.1-py3-none-any.whl", hash = "sha256:41bd71f284ca4d44a668816193e4025c950b002252081e387433656ae9a70a82"},
+    {file = "mkdocstrings-0.30.1.tar.gz", hash = "sha256:84a007aae9b707fb0aebfc9da23db4b26fc9ab562eb56e335e9ec480cb19744f"},
+]
+
+[package.dependencies]
+Jinja2 = ">=2.11.1"
+Markdown = ">=3.6"
+MarkupSafe = ">=1.1"
+mkdocs = ">=1.6"
+mkdocs-autorefs = ">=1.4"
+mkdocstrings-python = {version = ">=1.16.2", optional = true, markers = "extra == \"python\""}
+pymdown-extensions = ">=6.3"
+
+[package.extras]
+crystal = ["mkdocstrings-crystal (>=0.3.4)"]
+python = ["mkdocstrings-python (>=1.16.2)"]
+python-legacy = ["mkdocstrings-python-legacy (>=0.2.1)"]
+
+[[package]]
+name = "mkdocstrings-python"
+version = "2.0.3"
+description = "A Python handler for mkdocstrings."
+optional = false
+python-versions = ">=3.10"
+groups = ["docs"]
+files = [
+    {file = "mkdocstrings_python-2.0.3-py3-none-any.whl", hash = "sha256:0b83513478bdfd803ff05aa43e9b1fca9dd22bcd9471f09ca6257f009bc5ee12"},
+    {file = "mkdocstrings_python-2.0.3.tar.gz", hash = "sha256:c518632751cc869439b31c9d3177678ad2bfa5c21b79b863956ad68fc92c13b8"},
+]
+
+[package.dependencies]
+griffelib = ">=2.0"
+mkdocs-autorefs = ">=1.4"
+mkdocstrings = ">=0.30"
 
 [[package]]
 name = "moto"
@@ -3189,12 +3481,28 @@ version = "26.2"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"},
     {file = "packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"},
 ]
 markers = {main = "extra == \"data\" or extra == \"all\""}
+
+[[package]]
+name = "paginate"
+version = "0.5.7"
+description = "Divides large result sets into pages for easier browsing"
+optional = false
+python-versions = "*"
+groups = ["docs"]
+files = [
+    {file = "paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591"},
+    {file = "paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945"},
+]
+
+[package.extras]
+dev = ["pytest", "tox"]
+lint = ["black"]
 
 [[package]]
 name = "pandas"
@@ -3349,7 +3657,7 @@ version = "1.1.1"
 description = "Utility library for gitignore style pattern matching of file paths."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["dev", "docs"]
 files = [
     {file = "pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189"},
     {file = "pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a"},
@@ -3359,6 +3667,18 @@ files = [
 hyperscan = ["hyperscan (>=0.7)"]
 optional = ["typing-extensions (>=4)"]
 re2 = ["google-re2 (>=1.1)"]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
+optional = false
+python-versions = ">=3.10"
+groups = ["docs"]
+files = [
+    {file = "platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917"},
+    {file = "platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a"},
+]
 
 [[package]]
 name = "pluggy"
@@ -3589,6 +3909,35 @@ files = [
 ]
 
 [[package]]
+name = "properdocs"
+version = "1.6.7"
+description = "Project documentation with Markdown."
+optional = false
+python-versions = ">=3.9"
+groups = ["docs"]
+files = [
+    {file = "properdocs-1.6.7-py3-none-any.whl", hash = "sha256:6fa0cfa2e01bf338f684892c8a506cf70ea88ae7f3479c933b6fa20168101cbd"},
+    {file = "properdocs-1.6.7.tar.gz", hash = "sha256:adc7b16e562890af0e098a7e5b02e3a81c20894a87d6a28d345c9300de73c26e"},
+]
+
+[package.dependencies]
+click = ">=7.0"
+colorama = {version = ">=0.4", markers = "platform_system == \"Windows\""}
+ghp-import = ">=1.0"
+jinja2 = ">=2.11.1"
+markdown = ">=3.3.6"
+markupsafe = ">=2.0.1"
+packaging = ">=20.5"
+pathspec = ">=0.11.1"
+platformdirs = ">=2.2.0"
+pyyaml = ">=5.1"
+pyyaml-env-tag = ">=0.1"
+watchdog = ">=2.0"
+
+[package.extras]
+i18n = ["babel (>=2.9.0)"]
+
+[[package]]
 name = "py-partiql-parser"
 version = "0.6.3"
 description = "Pure Python PartiQL Parser"
@@ -3802,7 +4151,7 @@ version = "2.20.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["dev", "docs"]
 files = [
     {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
     {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
@@ -3810,6 +4159,25 @@ files = [
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "pymdown-extensions"
+version = "10.21.3"
+description = "Extension pack for Python Markdown."
+optional = false
+python-versions = ">=3.9"
+groups = ["docs"]
+files = [
+    {file = "pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6"},
+    {file = "pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354"},
+]
+
+[package.dependencies]
+markdown = ">=3.6"
+pyyaml = "*"
+
+[package.extras]
+extra = ["pygments (>=2.19.1)"]
 
 [[package]]
 name = "pyparsing"
@@ -3894,7 +4262,7 @@ version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-groups = ["main", "dev"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
     {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
@@ -3971,7 +4339,7 @@ version = "6.0.3"
 description = "YAML parser and emitter for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["dev", "docs"]
 files = [
     {file = "PyYAML-6.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f"},
     {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4"},
@@ -4047,6 +4415,21 @@ files = [
     {file = "pyyaml-6.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007"},
     {file = "pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"},
 ]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+description = "A custom YAML tag for referencing environment variables in YAML files."
+optional = false
+python-versions = ">=3.9"
+groups = ["docs"]
+files = [
+    {file = "pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04"},
+    {file = "pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff"},
+]
+
+[package.dependencies]
+pyyaml = "*"
 
 [[package]]
 name = "questionary"
@@ -4210,7 +4593,7 @@ version = "2.34.2"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"},
     {file = "requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed"},
@@ -4480,7 +4863,7 @@ version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-groups = ["main", "dev"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
@@ -4658,7 +5041,7 @@ version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
     {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
@@ -4670,6 +5053,49 @@ brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "b
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+description = "Filesystem events monitoring"
+optional = false
+python-versions = ">=3.9"
+groups = ["docs"]
+files = [
+    {file = "watchdog-6.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d1cdb490583ebd691c012b3d6dae011000fe42edb7a82ece80965b42abd61f26"},
+    {file = "watchdog-6.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bc64ab3bdb6a04d69d4023b29422170b74681784ffb9463ed4870cf2f3e66112"},
+    {file = "watchdog-6.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c897ac1b55c5a1461e16dae288d22bb2e412ba9807df8397a635d88f671d36c3"},
+    {file = "watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c"},
+    {file = "watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2"},
+    {file = "watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c"},
+    {file = "watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948"},
+    {file = "watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860"},
+    {file = "watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0"},
+    {file = "watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c"},
+    {file = "watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134"},
+    {file = "watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b"},
+    {file = "watchdog-6.0.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e6f0e77c9417e7cd62af82529b10563db3423625c5fce018430b249bf977f9e8"},
+    {file = "watchdog-6.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:90c8e78f3b94014f7aaae121e6b909674df5b46ec24d6bebc45c44c56729af2a"},
+    {file = "watchdog-6.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e7631a77ffb1f7d2eefa4445ebbee491c720a5661ddf6df3498ebecae5ed375c"},
+    {file = "watchdog-6.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c7ac31a19f4545dd92fc25d200694098f42c9a8e391bc00bdd362c5736dbf881"},
+    {file = "watchdog-6.0.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9513f27a1a582d9808cf21a07dae516f0fab1cf2d7683a742c498b93eedabb11"},
+    {file = "watchdog-6.0.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7a0e56874cfbc4b9b05c60c8a1926fedf56324bb08cfbc188969777940aef3aa"},
+    {file = "watchdog-6.0.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:e6439e374fc012255b4ec786ae3c4bc838cd7309a540e5fe0952d03687d8804e"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c"},
+    {file = "watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2"},
+    {file = "watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a"},
+    {file = "watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680"},
+    {file = "watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f"},
+    {file = "watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282"},
+]
+
+[package.extras]
+watchmedo = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "wcwidth"
@@ -4979,4 +5405,4 @@ snappy = ["python-snappy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.15"
-content-hash = "5b64a374c49d2f5aed54f30049afc17f353d75e68da173456694367b1f680b6e"
+content-hash = "14d6084cca725d9c88d11c1fbad707a342b5259d722602b659f1deef51b1c811"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,12 @@ readme = "README.md"
 license = "MIT"
 packages = [{ include = "hyperion" }]
 
+[tool.poetry.urls]
+Homepage = "https://github.com/tomasvotava/hyperion"
+Documentation = "https://tomasvotava.github.io/hyperion/"
+Repository = "https://github.com/tomasvotava/hyperion"
+Changelog = "https://github.com/tomasvotava/hyperion/blob/master/CHANGELOG.md"
+
 [tool.poetry.dependencies]
 python = ">=3.11,<3.15"
 
@@ -56,6 +62,20 @@ commitizen = "^4.4.1"
 mypy-boto3 = "^1.38.0"
 mypy-boto3-s3 = "^1.38.0"
 import-linter = ">=2.0,<3"
+
+# Docs toolchain. Optional so the default install, `--all-extras`, and the
+# `install-all` composite stay untouched; pulled only with `poetry install
+# --with docs` (locally and in .github/workflows/docs.yml).
+[tool.poetry.group.docs]
+optional = true
+
+[tool.poetry.group.docs.dependencies]
+mkdocs = ">=1.6,<2"
+mkdocs-material = ">=9.5,<10"
+mkdocstrings = { extras = ["python"], version = ">=0.27,<0.31" }
+mkdocs-gen-files = ">=0.5,<0.6"
+mkdocs-literate-nav = ">=0.6,<0.7"
+mkdocs-section-index = ">=0.3,<0.4"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Closes #175

## Summary

Introduces a [Diataxis](https://diataxis.fr/)-structured **mkdocs + mkdocs-material** documentation site with an auto-generated API reference, published to **GitHub Pages**. Supersedes the flat `README.md` / `docs/asset_collections.md` layout; the v1.0.0 docs refresh is the content baseline.

Site URL (after first `master` deploy): <https://tomasvotava.github.io/hyperion/>

## What's included

- **`mkdocs.yml`** — Material theme, four-quadrant nav, `mkdocstrings` (Google docstrings), `gen-files` + `literate-nav` + `section-index`. No Python-tagged YAML (keeps pre-commit `check-yaml` green).
- **`docs/gen_ref_pages.py`** — auto-generates the API reference from an explicit **v1.0 public-module allow-list** (39 modules). Deprecation shims (`hyperion.entities/infrastructure/_compat`, the `hyperion.catalog` namespace shim, `application.persistent_cache`, `catalog.schema`) are excluded by omission and verified absent from the built site.
- **Diataxis tree** under `docs/`:
  - **Tutorials** — first DataLakeAsset (runnable, no AWS), building a custom Source
  - **How-to** — install/extras, env config, feature/persistent assets, cached catalog, asset collections (migrated from `docs/asset_collections.md` as a tracked rename), schemas, repartition, geo, running sources
  - **Reference** — auto API reference + pre-1.0 migration guide (links the pinned `CHANGELOG.md` guide as single source of truth)
  - **Explanation** — architecture, assets & catalog, ports & adapters (distilled from the internal DDD plan + `.importlinter`), lite-core & extras
- **`pyproject.toml`** — `[tool.poetry.urls]` (adds a Documentation link to the PyPI page) and an **optional** `[tool.poetry.group.docs]`; `poetry.lock` regenerated. The default install, `--all-extras`, and the `install-all` composite are unaffected (verified: `--all-extras --sync --dry-run` would *remove* mkdocs).
- **`.github/workflows/docs.yml`** — strict build on every PR/push; **uploads the rendered site as a `docs-site` artifact on PRs** so reviewers can peruse it before it's published; deploys to Pages on `master` (`actions/configure-pages@v5` with `enablement: true`). Sets `NO_MKDOCS_2_WARNING` to silence the mkdocs-material 9.7 promo banner.
- **README** trimmed (602 → ~120 lines) to a landing page linking the site; `.gitignore` guards the generated reference tree.

## Verification

- `mkdocs build --strict` → exit 0, **no warnings**.
- No stale pre-1.0 import paths or old `Catalog(*_bucket=)` in copyable examples; shim reference pages absent from the build.
- pre-commit hygiene hooks pass on all changed files; commit is `docs:` (no commitizen version bump).

## Reviewer note — GitHub Pages enablement

The deploy job uses `actions/configure-pages@v5` with `enablement: true` to auto-enable Pages on the first `master` run. **If the repository's Actions token lacks Pages-admin permission**, that step will fail and Pages must be enabled once manually: *Settings → Pages → Build and deployment → Source = GitHub Actions*. After that the workflow is idempotent.

On this PR only the **build** job runs (no deploy); download the **`docs-site`** workflow artifact to preview the rendered site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)