### PR TITLE
fix(geo): honor get_nearest threshold and guard meters_to_degrees at the poles

### DIFF
--- a/hyperion/domain/geo.py
+++ b/hyperion/domain/geo.py
@@ -56,7 +56,16 @@ def meters_to_degrees(meters: float, at_latitude: float) -> tuple[float, float]:
 
     Returns:
         tuple[float, float]: The distance in degrees for latitude and longitude.
+
+    Raises:
+        ValueError: If ``at_latitude`` is ±90 (the poles), where longitude
+            degrees are geometrically undefined (cos(±90°) = 0).
     """
+    if abs(at_latitude) >= 90:
+        raise ValueError(
+            f"Cannot convert meters to longitude degrees at latitude {at_latitude}: "
+            "longitude degrees are undefined at the poles (|latitude| >= 90)."
+        )
     return meters / LATITUDE_DEGREE_TO_METERS, meters / (
         LATITUDE_DEGREE_TO_METERS * math.cos(math.radians(at_latitude))
     )
@@ -185,6 +194,8 @@ class Location:
         nearest: tuple[AnyLocation, float] | None = None
         for other in others:
             distance = self.get_distance(other, approximate=approximate)
+            if threshold is not None and distance > threshold:
+                continue
             if nearest is None or nearest[1] > distance:
                 nearest = (other, distance)
         if nearest is None:

--- a/tests/infrastructure/geo/test_location.py
+++ b/tests/infrastructure/geo/test_location.py
@@ -8,6 +8,7 @@ shim stays exercised, and pin the (now cache-less) distance math.
 """
 
 import datetime
+import math
 
 import numpy as np
 import pytest
@@ -93,6 +94,34 @@ class TestGetNearest:
         with pytest.raises(ValueError, match="None of the given locations"):
             origin.get_nearest([])
 
+    def test_threshold_large_enough_returns_nearest(self) -> None:
+        # near is ~111 m away; a 200 m threshold should include it.
+        origin = Location(0.0, 0.0)
+        near = Location(0.0, 0.001)  # ~111 m
+        far = Location(10.0, 10.0)
+        result = origin.get_nearest([far, near], threshold=200.0)
+        assert result is near
+
+    def test_threshold_smaller_than_all_raises(self) -> None:
+        # near is ~111 m away; a 10 m threshold excludes every candidate.
+        origin = Location(0.0, 0.0)
+        near = Location(0.0, 0.001)  # ~111 m
+        far = Location(10.0, 10.0)
+        with pytest.raises(ValueError, match="None of the given locations"):
+            origin.get_nearest([far, near], threshold=10.0)
+
+    def test_threshold_nearest_among_qualifying_candidates_wins(self) -> None:
+        # Three candidates: close (~111 m), mid (~556 m), far (very far).
+        # threshold=700 m: close and mid qualify, far is excluded.
+        # close is the nearest of the qualifying candidates and must win.
+        origin = Location(0.0, 0.0)
+        close = Location(0.0, 0.001)  # ~111 m  — qualifies
+        mid = Location(0.0, 0.005)  # ~556 m  — qualifies
+        far = Location(10.0, 10.0)  # far above threshold — excluded
+        # Feed in reverse distance order to confirm ordering isn't from list position.
+        result = origin.get_nearest([mid, far, close], threshold=700.0)
+        assert result is close
+
 
 class TestNamedLocation:
     def test_frozen_and_equal(self) -> None:
@@ -125,6 +154,22 @@ class TestMetersToDegrees:
         # cos(60deg) = 0.5 → 1 longitude degree covers half the equatorial meters.
         _, lon_deg = meters_to_degrees(111_000, 60.0)
         assert lon_deg == pytest.approx(2.0, rel=1e-9)
+
+    def test_north_pole_raises(self) -> None:
+        with pytest.raises(ValueError, match="poles"):
+            meters_to_degrees(1000, 90.0)
+
+    def test_south_pole_raises(self) -> None:
+        with pytest.raises(ValueError, match="poles"):
+            meters_to_degrees(1000, -90.0)
+
+    def test_normal_latitudes_return_finite_values(self) -> None:
+        lat_deg, lon_deg = meters_to_degrees(1000, 0.0)
+        assert math.isfinite(lat_deg)
+        assert math.isfinite(lon_deg)
+        lat_deg2, lon_deg2 = meters_to_degrees(1000, 60.0)
+        assert math.isfinite(lat_deg2)
+        assert math.isfinite(lon_deg2)
 
 
 class TestSpatialKMeans:


### PR DESCRIPTION
Closes #144

- `Location.get_nearest` now skips candidates beyond `threshold` and raises `ValueError` when none qualify (honors the existing docstring contract).
- `meters_to_degrees` raises `ValueError` at `|latitude| >= 90` where longitude degrees are undefined, instead of returning ~1e15 garbage.

Tests: `tests/infrastructure/geo/test_location.py` (24 passed). All gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)