### PR TITLE
refactor(storage): use head_object for S3Storage.get_attributes

### DIFF
--- a/hyperion/adapters/storage/s3.py
+++ b/hyperion/adapters/storage/s3.py
@@ -105,9 +105,7 @@ class S3Storage:
         pagination_config: PaginatorConfigTypeDef = {}
         full_prefix = self._full_key(prefix)
         logger.debug("Listing S3 bucket contents.", bucket=self._bucket, prefix=full_prefix)
-        for response in paginator.paginate(
-            Bucket=self._bucket, Prefix=full_prefix, PaginationConfig=pagination_config
-        ):
+        for response in paginator.paginate(Bucket=self._bucket, Prefix=full_prefix, PaginationConfig=pagination_config):
             if "Contents" not in response:
                 continue
             for s3_object in response["Contents"]:
@@ -127,18 +125,26 @@ class S3Storage:
         self._client.delete_object(Bucket=self._bucket, Key=self._full_key(key))
 
     def get_attributes(self, key: str) -> ObjectAttributes:
+        """Return metadata for *key* via ``head_object``.
+
+        .. note::
+            For multipart uploads, ``head_object`` returns a composite ETag
+            (``"<md5>-<part_count>"``) that is **not** a plain content MD5
+            and differs from the value ``get_object_attributes`` would return.
+            Because this adapter only writes objects through single-part
+            ``upload_fileobj`` calls (see :meth:`put` / :meth:`put_async`),
+            the two APIs are equivalent in practice.  Callers must not treat
+            ``etag`` as a portable content MD5 across backends or upload
+            strategies.
+        """
         try:
-            response = self._client.get_object_attributes(
-                Bucket=self._bucket,
-                Key=self._full_key(key),
-                ObjectAttributes=["ETag", "Checksum", "ObjectParts", "StorageClass", "ObjectSize"],
-            )
+            response = self._client.head_object(Bucket=self._bucket, Key=self._full_key(key))
         except botocore.exceptions.ClientError as error:
             if _is_not_found(error):
                 raise ObjectNotFoundError(key) from error
             raise
         return ObjectAttributes(
             etag=response["ETag"].strip('"'),
-            size=int(response["ObjectSize"]),
+            size=int(response["ContentLength"]),
             last_modified=response["LastModified"],
         )

--- a/hyperion/adapters/storage/s3.py
+++ b/hyperion/adapters/storage/s3.py
@@ -131,11 +131,12 @@ class S3Storage:
             For multipart uploads, ``head_object`` returns a composite ETag
             (``"<md5>-<part_count>"``) that is **not** a plain content MD5
             and differs from the value ``get_object_attributes`` would return.
-            Because this adapter only writes objects through single-part
-            ``upload_fileobj`` calls (see :meth:`put` / :meth:`put_async`),
-            the two APIs are equivalent in practice.  Callers must not treat
-            ``etag`` as a portable content MD5 across backends or upload
-            strategies.
+            :meth:`put` / :meth:`put_async` go through boto3's managed
+            ``upload_fileobj``, which switches to a multipart upload for
+            payloads above ``TransferConfig.multipart_threshold`` (8 MiB by
+            default), so larger objects do get a composite ETag here. Callers
+            must not treat ``etag`` as a portable content MD5 across backends
+            or upload strategies.
         """
         try:
             response = self._client.head_object(Bucket=self._bucket, Key=self._full_key(key))


### PR DESCRIPTION
Closes #149

Switches `get_attributes` from `get_object_attributes` to `head_object` (more idiomatic, broadly supported by S3-compatible stores, fewer IAM permissions). Maps etag/size/last_modified; keeps the `ObjectNotFoundError` mapping. Docstring notes the multipart-ETag caveat.

`refactor:` is non-bumping under commitizen. Tests: full storage suite incl. S3/moto (42 passed). All gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)