### PR TITLE
fix(queue): InMemoryQueue receipt handles collide on identical timestamps

### DIFF
--- a/hyperion/adapters/queue/memory.py
+++ b/hyperion/adapters/queue/memory.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from uuid import uuid4
+
 from hyperion.domain.messages import Message
 from hyperion.ports.queue import Queue
 
@@ -12,11 +14,17 @@ class InMemoryQueue(Queue):
         self._messages: list[Message] = []
 
     def send(self, message: Message) -> None:
+        if message.receipt_handle is None:
+            message.receipt_handle = uuid4().hex
         self._messages.append(message)
 
     def delete(self, receipt_handle: str) -> None:
-        """Delete the message using the created as isoformat."""
+        """Delete the message identified by *receipt_handle*.
+
+        Matches on the ``receipt_handle`` field assigned by :meth:`send`.
+        Deleting an unknown handle is a no-op.
+        """
         for message in self._messages:
-            if message.created.isoformat() == receipt_handle:
+            if message.receipt_handle == receipt_handle:
                 self._messages.remove(message)
                 break

--- a/tests/infrastructure/test_message_queue.py
+++ b/tests/infrastructure/test_message_queue.py
@@ -113,13 +113,21 @@ class TestInMemoryQueue:
         queue.send(message)
         assert queue._messages == [message]
 
+    def test_send_assigns_receipt_handle(self) -> None:
+        queue = InMemoryQueue()
+        message = _datalake_message()
+        assert message.receipt_handle is None
+        queue.send(message)
+        assert message.receipt_handle is not None
+
     def test_delete_by_receipt_handle(self) -> None:
         queue = InMemoryQueue()
         message_a = _datalake_message()
         message_b = SourceBackfillMessage(source="s", start_date=datetime.datetime(2025, 2, 1, tzinfo=UTC))
         queue.send(message_a)
         queue.send(message_b)
-        queue.delete(message_a.created.isoformat())
+        assert message_a.receipt_handle is not None
+        queue.delete(message_a.receipt_handle)
         assert queue._messages == [message_b]
 
     def test_delete_missing_handle_is_noop(self) -> None:
@@ -127,6 +135,27 @@ class TestInMemoryQueue:
         queue.send(_datalake_message())
         queue.delete("does-not-exist")
         assert len(queue._messages) == 1
+
+    def test_identical_timestamps_get_distinct_handles(self) -> None:
+        """Regression: two messages with the same created timestamp must get
+        distinct receipt handles so delete() removes exactly one of them."""
+        shared_ts = datetime.datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+        message_a = _datalake_message()
+        message_a.created = shared_ts
+        message_b = SourceBackfillMessage(
+            source="s",
+            start_date=datetime.datetime(2025, 2, 1, tzinfo=UTC),
+            created=shared_ts,
+        )
+        queue = InMemoryQueue()
+        queue.send(message_a)
+        queue.send(message_b)
+
+        assert message_a.receipt_handle != message_b.receipt_handle
+
+        assert message_a.receipt_handle is not None
+        queue.delete(message_a.receipt_handle)
+        assert queue._messages == [message_b]
 
 
 class TestFileQueue:


### PR DESCRIPTION
Closes #159

`send()` assigns a unique `uuid4().hex` receipt handle (if unset); `delete()` matches on it instead of `created.isoformat()`, so messages within the same microsecond no longer share a handle. Public API unchanged.

Tests: `TestInMemoryQueue` incl. a same-timestamp regression test (5 passed). All gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)