### PR TITLE
fix(queue): FileQueue._flush is not atomic across filesystems

### DIFF
--- a/hyperion/adapters/queue/filesystem.py
+++ b/hyperion/adapters/queue/filesystem.py
@@ -55,11 +55,24 @@ class FileQueue(Queue):
             {"message_type": message.__class__.__name__, "message": message.model_dump_json()}
             for message in self._messages
         ]
-        self.queue_path.parent.mkdir(parents=True, exist_ok=True)
-        with tempfile.NamedTemporaryFile("w", dir=self.queue_path.parent, delete=False) as tmp_file:
-            json.dump(serializable_list, tmp_file)
-            tmp_path = tmp_file.name
-        os.replace(tmp_path, self.queue_path)  # noqa: PTH105 - atomic same-dir replace
+        parent = self.queue_path.parent
+        parent.mkdir(parents=True, exist_ok=True)
+        tmp_path: str | None = None
+        try:
+            # encoding pinned to utf-8 to match iter_messages_from_file's reader;
+            # flush + fsync guarantee the bytes hit disk before the atomic rename.
+            with tempfile.NamedTemporaryFile("w", dir=parent, delete=False, encoding="utf-8") as tmp_file:
+                tmp_path = tmp_file.name
+                json.dump(serializable_list, tmp_file)
+                tmp_file.flush()
+                os.fsync(tmp_file.fileno())
+            os.replace(tmp_path, self.queue_path)  # noqa: PTH105 - atomic same-dir replace
+        except Exception:
+            # delete=False means a failure before the rename would otherwise
+            # strand the temp file next to the queue file.
+            if tmp_path is not None:
+                Path(tmp_path).unlink(missing_ok=True)
+            raise
         logger.info(
             f"Flushed {len(self._messages)} from FileQueue.",
             queue=self,

--- a/hyperion/adapters/queue/filesystem.py
+++ b/hyperion/adapters/queue/filesystem.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-import shutil
+import os
 import tempfile
 from collections.abc import Iterator
 from pathlib import Path
@@ -55,9 +55,11 @@ class FileQueue(Queue):
             {"message_type": message.__class__.__name__, "message": message.model_dump_json()}
             for message in self._messages
         ]
-        with tempfile.NamedTemporaryFile("w", delete=False) as tmp_file:
+        self.queue_path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile("w", dir=self.queue_path.parent, delete=False) as tmp_file:
             json.dump(serializable_list, tmp_file)
-        shutil.move(tmp_file.name, self.queue_path)
+            tmp_path = tmp_file.name
+        os.replace(tmp_path, self.queue_path)  # noqa: PTH105 - atomic same-dir replace
         logger.info(
             f"Flushed {len(self._messages)} from FileQueue.",
             queue=self,

--- a/tests/infrastructure/test_message_queue.py
+++ b/tests/infrastructure/test_message_queue.py
@@ -232,6 +232,15 @@ class TestFileQueue:
         with pytest.raises(NotImplementedError):
             queue.delete("anything")
 
+    def test_flush_leaves_no_temp_file_sibling(self, tmp_path: Path) -> None:
+        queue_path = tmp_path / "queue.json"
+        queue = FileQueue(queue_path)
+        with queue:
+            queue.send(_datalake_message())
+        # The directory must contain exactly the queue file — no leftover temp files.
+        siblings = list(tmp_path.iterdir())
+        assert siblings == [queue_path]
+
 
 class TestSQSQueue:
     @pytest.fixture

--- a/tests/infrastructure/test_message_queue.py
+++ b/tests/infrastructure/test_message_queue.py
@@ -241,6 +241,33 @@ class TestFileQueue:
         siblings = list(tmp_path.iterdir())
         assert siblings == [queue_path]
 
+    def test_flush_cleans_up_temp_file_on_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        queue_path = tmp_path / "queue.json"
+        queue = FileQueue(queue_path)
+
+        def _boom(*_args: Any, **_kwargs: Any) -> None:
+            raise RuntimeError("serialization failed")
+
+        monkeypatch.setattr("hyperion.adapters.queue.filesystem.json.dump", _boom)
+        with pytest.raises(RuntimeError, match="serialization failed"), queue:
+            queue.send(_datalake_message())
+        # The failed flush must leave neither a queue file nor a stranded temp file.
+        assert list(tmp_path.iterdir()) == []
+
+    def test_flush_roundtrips_non_ascii_payload(self, tmp_path: Path) -> None:
+        queue_path = tmp_path / "queue.json"
+        queue = FileQueue(queue_path)
+        message = SourceBackfillMessage(
+            source="Pňačšľ-Žřáböľ",  # non-ASCII: would corrupt under a non-utf-8 default encoding
+            start_date=datetime.datetime(2025, 2, 1, tzinfo=UTC),
+        )
+        with queue:
+            queue.send(message)
+        loaded = list(FileQueue.iter_messages_from_file(queue_path))
+        assert len(loaded) == 1
+        assert isinstance(loaded[0], SourceBackfillMessage)
+        assert loaded[0].source == "Pňačšľ-Žřáböľ"
+
 
 class TestSQSQueue:
     @pytest.fixture


### PR DESCRIPTION
Closes #158

Writes the temp file in the destination directory and `os.replace`s onto the queue path for a guaranteed atomic same-filesystem rename, mirroring the keyval filesystem adapter. Replaces the cross-filesystem `shutil.move`.

Tests: `TestFileQueue` incl. no-leftover-temp assertion (10 passed). All gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)