### PR TITLE
fix(cache): DynamoDBCache._clear only clears the first scan page

### DIFF
--- a/hyperion/adapters/cache/dynamodb.py
+++ b/hyperion/adapters/cache/dynamodb.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import time
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import boto3
 
 from hyperion.log import get_logger
 from hyperion.ports.cache import DEFAULT_TTL_SECONDS, Cache, CachingError
+
+if TYPE_CHECKING:
+    from mypy_boto3_dynamodb.type_defs import ScanInputTableScanTypeDef
 
 DYNAMODB_MAX_LENGTH = 65535
 
@@ -70,13 +73,23 @@ class DynamoDBCache(Cache):
         """
         Deletes all items in the table.
 
-        Warning: DynamoDB doesn't have a built-in clear mechanism, so we scan and delete all items manually.
+        Warning: DynamoDB doesn't have a built-in clear mechanism, so we scan and delete all
+        items manually. Pagination is handled via ``LastEvaluatedKey`` so tables larger than
+        the ~1 MB scan page limit are cleared completely.
         """
         logger.info("Clearing cache.", cache_table=self.table_name)
-        scan = self.table.scan()
+        scan_kwargs: ScanInputTableScanTypeDef = {
+            "ProjectionExpression": "#k",
+            "ExpressionAttributeNames": {"#k": "key"},
+        }
         with self.table.batch_writer() as batch:
-            for item in scan["Items"]:
-                batch.delete_item(Key={"key": item["key"]})
+            while True:
+                response = self.table.scan(**scan_kwargs)
+                for item in response.get("Items", []):
+                    batch.delete_item(Key={"key": item["key"]})
+                if "LastEvaluatedKey" not in response:
+                    break
+                scan_kwargs["ExclusiveStartKey"] = response["LastEvaluatedKey"]
 
     def _hit(self, key: str) -> bool:
         cache_key = self._key(key)

--- a/tests/infrastructure/test_cache.py
+++ b/tests/infrastructure/test_cache.py
@@ -306,3 +306,44 @@ def test_stats_overwrite_counts_each_set(instance: Cache) -> None:
     after = instance.stats
     assert (after - before).get("sets") == 2
     assert instance.get("k") == "v2"
+
+
+def test_dynamodb_cache_clear_paginates_all_pages(
+    dynamodb_cache: DynamoDBCache,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_clear must follow LastEvaluatedKey until exhausted, not just delete the first page."""
+    page1_items = [{"key": "page1-item-a"}, {"key": "page1-item-b"}]
+    page2_items = [{"key": "page2-item-c"}]
+    last_key = {"key": "page1-item-b"}
+
+    call_count = 0
+
+    def _fake_scan(**kwargs: object) -> dict[str, object]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return {"Items": page1_items, "LastEvaluatedKey": last_key}
+        return {"Items": page2_items}
+
+    deleted_keys: list[str] = []
+
+    class _FakeBatchWriter:
+        def __enter__(self) -> "_FakeBatchWriter":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def delete_item(self, Key: dict[str, str]) -> None:  # noqa: N803
+            deleted_keys.append(Key["key"])
+
+    monkeypatch.setattr(dynamodb_cache.table, "scan", _fake_scan)
+    monkeypatch.setattr(dynamodb_cache.table, "batch_writer", lambda: _FakeBatchWriter())
+
+    dynamodb_cache._clear()
+
+    assert call_count == 2, "scan must be called twice (once per page)"
+    assert sorted(deleted_keys) == sorted([item["key"] for item in page1_items + page2_items]), (
+        "all items from both pages must be deleted"
+    )

--- a/tests/infrastructure/test_cache.py
+++ b/tests/infrastructure/test_cache.py
@@ -323,7 +323,11 @@ def test_dynamodb_cache_clear_paginates_all_pages(
         nonlocal call_count
         call_count += 1
         if call_count == 1:
+            assert "ExclusiveStartKey" not in kwargs, "first scan must not carry a cursor"
             return {"Items": page1_items, "LastEvaluatedKey": last_key}
+        assert kwargs.get("ExclusiveStartKey") == last_key, (
+            "subsequent scans must thread the previous page's LastEvaluatedKey as ExclusiveStartKey"
+        )
         return {"Items": page2_items}
 
     deleted_keys: list[str] = []


### PR DESCRIPTION
Closes #155

Paginates the scan on `LastEvaluatedKey`/`ExclusiveStartKey` until exhausted (typed via `ScanInputTableScanTypeDef`, mirroring `DynamoDBStore._iter_all_keys`) so tables larger than the ~1 MB scan page are fully cleared.

Tests: existing dynamodb clear contract + new monkeypatched pagination test (2 passed). All gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)