### PR TITLE
fix(keyval): make FilesystemStore._set_raw durable and leak-free

### DIFF
--- a/hyperion/adapters/keyval/filesystem.py
+++ b/hyperion/adapters/keyval/filesystem.py
@@ -3,7 +3,8 @@
 One file per (hashed, prefixed) key under a root directory, mirroring the
 ``LocalFileCache`` idiom. Keys are url-safe-base64 encoded into filenames so
 arbitrary keys (containing ``/``, ``:`` ...) are safe and reversible. Writes
-are atomic (write to a temp file in the same directory, then ``os.replace``).
+are atomic and durable (write to a temp file in the same directory, ``fsync``,
+then ``os.replace``; the temp file is removed if the write fails).
 """
 
 from __future__ import annotations
@@ -55,10 +56,21 @@ class FilesystemStore(KeyValueStore):
 
     def _set_raw(self, hashed_key: str, compresed_value: bytes) -> None:
         key_path = self._path(hashed_key)
-        with tempfile.NamedTemporaryFile("wb", dir=self.root_path, delete=False) as tmp_file:
-            tmp_file.write(compresed_value)
-            tmp_path = tmp_file.name
-        os.replace(tmp_path, key_path)  # noqa: PTH105 - atomic same-dir replace
+        tmp_path: str | None = None
+        try:
+            # flush + fsync guarantee the bytes hit disk before the atomic rename.
+            with tempfile.NamedTemporaryFile("wb", dir=self.root_path, delete=False) as tmp_file:
+                tmp_path = tmp_file.name
+                tmp_file.write(compresed_value)
+                tmp_file.flush()
+                os.fsync(tmp_file.fileno())
+            os.replace(tmp_path, key_path)  # noqa: PTH105 - atomic same-dir replace
+        except Exception:
+            # delete=False means a failure before the rename would otherwise
+            # strand the temp file in root_path.
+            if tmp_path is not None:
+                Path(tmp_path).unlink(missing_ok=True)
+            raise
 
     def _delete_raw(self, hashed_key: str) -> None:
         self._path(hashed_key).unlink(missing_ok=True)

--- a/hyperion/adapters/keyval/filesystem.py
+++ b/hyperion/adapters/keyval/filesystem.py
@@ -65,12 +65,13 @@ class FilesystemStore(KeyValueStore):
                 tmp_file.flush()
                 os.fsync(tmp_file.fileno())
             os.replace(tmp_path, key_path)  # noqa: PTH105 - atomic same-dir replace
-        except Exception:
-            # delete=False means a failure before the rename would otherwise
-            # strand the temp file in root_path.
+        finally:
+            # delete=False: drop the temp file if anything before the rename is
+            # interrupted -- including BaseException (e.g. KeyboardInterrupt).
+            # On success os.replace already moved it, so unlink is a
+            # missing_ok no-op.
             if tmp_path is not None:
                 Path(tmp_path).unlink(missing_ok=True)
-            raise
 
     def _delete_raw(self, hashed_key: str) -> None:
         self._path(hashed_key).unlink(missing_ok=True)

--- a/tests/adapters/keyval/test_filesystem.py
+++ b/tests/adapters/keyval/test_filesystem.py
@@ -112,3 +112,19 @@ def test_compression_roundtrip(tmp_path: Path, compression: str | None) -> None:
     payload = "hello-" * 200
     store.set("k", payload)
     assert store.get("k") == payload
+
+
+def test_set_cleans_up_temp_file_on_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "kv"
+    store = FilesystemStore(root)
+
+    def _boom(_fd: int) -> None:
+        raise OSError("fsync failed")
+
+    # fsync runs after the temp file is created/written but before the rename.
+    monkeypatch.setattr("hyperion.adapters.keyval.filesystem.os.fsync", _boom)
+    with pytest.raises(OSError, match="fsync failed"):
+        store.set("k", "v")
+    # The failed write must leave neither a value file nor a stranded temp file.
+    assert list(root.iterdir()) == []
+    assert store.get("k") is None


### PR DESCRIPTION
Follow-up to #185.

`FilesystemStore._set_raw` is the atomic-write pattern that #158/#185 was explicitly told to mirror. The gemini-code-assist review on #185 identified durability/leak gaps in the FileQueue copy; the keyval sibling had the same two:

- **Durability:** no `flush()`/`fsync()` before `os.replace` — a crash right after the rename could leave an empty/truncated value file. → now `flush()` + `os.fsync()`.
- **Temp-file leak:** `delete=False` with no cleanup — a write failure stranded the temp file in `root_path`. → now removed via `Path(...).unlink(missing_ok=True)` on error, then re-raise.

The third FileQueue gap (text encoding) does **not** apply — this writer is binary (`"wb"`).

Out of scope: `LocalFileCache`'s write path has separate, larger safety issues already tracked in #156 — deliberately not folded in here.

Tests: new `test_set_cleans_up_temp_file_on_error` + existing suite (19 passed). ruff / ruff-format / mypy-strict / import-linter all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)