### PR TITLE
fix(queue): clean up FileQueue._flush temp file on BaseException via try/finally

### DIFF
--- a/hyperion/adapters/queue/filesystem.py
+++ b/hyperion/adapters/queue/filesystem.py
@@ -67,12 +67,13 @@ class FileQueue(Queue):
                 tmp_file.flush()
                 os.fsync(tmp_file.fileno())
             os.replace(tmp_path, self.queue_path)  # noqa: PTH105 - atomic same-dir replace
-        except Exception:
-            # delete=False means a failure before the rename would otherwise
-            # strand the temp file next to the queue file.
+        finally:
+            # delete=False: drop the temp file if anything before the rename is
+            # interrupted -- including BaseException (e.g. KeyboardInterrupt).
+            # On success os.replace already moved it, so unlink is a
+            # missing_ok no-op.
             if tmp_path is not None:
                 Path(tmp_path).unlink(missing_ok=True)
-            raise
         logger.info(
             f"Flushed {len(self._messages)} from FileQueue.",
             queue=self,

--- a/hyperion/adapters/queue/filesystem.py
+++ b/hyperion/adapters/queue/filesystem.py
@@ -67,11 +67,10 @@ class FileQueue(Queue):
                 tmp_file.flush()
                 os.fsync(tmp_file.fileno())
             os.replace(tmp_path, self.queue_path)  # noqa: PTH105 - atomic same-dir replace
+            tmp_path = None  # renamed into place; nothing for the finally to clean up
         finally:
             # delete=False: drop the temp file if anything before the rename is
             # interrupted -- including BaseException (e.g. KeyboardInterrupt).
-            # On success os.replace already moved it, so unlink is a
-            # missing_ok no-op.
             if tmp_path is not None:
                 Path(tmp_path).unlink(missing_ok=True)
         logger.info(


### PR DESCRIPTION
Follow-up to #185 / sibling of #188.

The gemini-code-assist review on #188 (`FilesystemStore._set_raw`) correctly noted that `except Exception: … raise` misses `BaseException` (e.g. `KeyboardInterrupt` during the write), which still strands the `delete=False` temp file. #188 adopts `try/finally`; #185 had already merged with the old `except Exception` form, so `FileQueue._flush` (the explicitly-mirrored sibling) needs the same change to stay consistent.

- `try/finally` always cleans up the temp file, including on `BaseException`.
- Success path is unchanged: `os.replace` already renamed the temp away, so `Path(...).unlink(missing_ok=True)` is a no-op.
- Kept `tmp_path: str | None` annotated (mypy-strict rejects the unannotated form).

Tests: existing `TestFileQueue` incl. `test_flush_cleans_up_temp_file_on_error` (12 passed). ruff / ruff-format / mypy-strict / import-linter all green. Branched off current `master` (post-#185 merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)