### PR TITLE
perf(keyval): skip redundant unlink on FilesystemStore._set_raw success path

### DIFF
--- a/hyperion/adapters/keyval/filesystem.py
+++ b/hyperion/adapters/keyval/filesystem.py
@@ -65,11 +65,10 @@ class FilesystemStore(KeyValueStore):
                 tmp_file.flush()
                 os.fsync(tmp_file.fileno())
             os.replace(tmp_path, key_path)  # noqa: PTH105 - atomic same-dir replace
+            tmp_path = None  # renamed into place; nothing for the finally to clean up
         finally:
             # delete=False: drop the temp file if anything before the rename is
             # interrupted -- including BaseException (e.g. KeyboardInterrupt).
-            # On success os.replace already moved it, so unlink is a
-            # missing_ok no-op.
             if tmp_path is not None:
                 Path(tmp_path).unlink(missing_ok=True)
 


### PR DESCRIPTION
Follow-up to merged #188; sibling of open #189.

The gemini-code-assist review on #189 correctly noted that the `try/finally` temp-file cleanup performs an unnecessary `Path(...).unlink(missing_ok=True)` syscall on **every successful write**. Setting `tmp_path = None` right after a successful `os.replace` makes the `finally` a no-op on the (common) success path while still cleaning up when an exception occurs before/at the rename.

#188 (which added the `try/finally` to `FilesystemStore._set_raw`) had already merged before this refinement, so master needs it as a standalone change to stay byte-for-byte consistent with the FileQueue sibling in #189.

Tests: existing keyval suite incl. `test_set_cleans_up_temp_file_on_error` (19 passed). ruff / ruff-format / mypy-strict / import-linter all green. Branched off current `master` (post-#188 merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)