### PR TITLE
fix: cache, storage & catalog follow-up bug/perf fixes (#147 #148 #152 #156 #157)

### DIFF
--- a/hyperion/adapters/cache/filesystem.py
+++ b/hyperion/adapters/cache/filesystem.py
@@ -17,12 +17,8 @@ from typing import IO, Literal, overload
 from hyperion.log import get_logger
 from hyperion.ports.cache import DEFAULT_TTL_SECONDS, Cache, CacheKeyOpenMode
 
-DEFAULT_LOCAL_FILE_CACHE_MAX_SIZE = 256 * (1024**2)
-
-# Stable, namespaced default root under the system temp dir. Using a fixed
-# subdir (instead of tempfile.mkdtemp()) means default-constructed instances
-# share one reusable directory rather than leaking a fresh tmp dir each time.
 DEFAULT_LOCAL_FILE_CACHE_DIRNAME = "hyperion-cache"
+DEFAULT_LOCAL_FILE_CACHE_MAX_SIZE = 256 * (1024**2)
 
 logger = get_logger("cache")
 
@@ -40,9 +36,6 @@ class LocalFileCache(Cache):
         use_compression: bool = True,
     ) -> None:
         super().__init__(prefix, hash_keys, default_ttl)
-        # A stable namespaced dir under the system temp dir is reused across
-        # instances/processes -- unlike tempfile.mkdtemp(), which leaked a
-        # fresh, never-cleaned-up directory per default-constructed instance.
         self.root_path = root_path or (Path(tempfile.gettempdir()) / DEFAULT_LOCAL_FILE_CACHE_DIRNAME)
         if self.root_path.exists() and not self.root_path.is_dir():
             raise ValueError(f"Given local cache path ({self.root_path.as_posix()}) is not a directory.")
@@ -52,9 +45,6 @@ class LocalFileCache(Cache):
         logger.info(f"Initialized LocalFileCache in {self.root_path.as_posix()}.", root_path=self.root_path.as_posix())
         if not hash_keys:
             logger.warning("When using filesystem cache, it is recommended to hash keys.")
-        # Size enforcement is deferred to write time (see _perform_set). Doing a
-        # full O(n*log n) sorted dir scan in __init__ blocked construction for
-        # large caches.
 
     def _assert_root_path(self) -> None:
         self.root_path.mkdir(parents=True, exist_ok=True)
@@ -99,9 +89,8 @@ class LocalFileCache(Cache):
             with key_path.open("r+") as file:
                 file.seek(0)
                 yield file
-                # r+ does not truncate: a shorter rewrite ("hello" -> "hi")
-                # would otherwise leave trailing bytes ("hilo"). Truncate at
-                # the caller's final position to honour the overwrite contract.
+                # r+ does not truncate; without this a shorter rewrite leaves
+                # trailing bytes from the previous value.
                 file.truncate(file.tell())
         elif mode == "bytes":
             with key_path.open("r+b") as file:
@@ -119,7 +108,6 @@ class LocalFileCache(Cache):
             return
         total_size = self.get_total_size()
         if total_size <= self.max_size:
-            # Cheap O(n) stat sum already done; skip the O(n*log n) sort+evict.
             return
         keys_ordered = sorted(self.root_path.iterdir(), key=lambda key: key.stat().st_mtime)
         while total_size > self.max_size:
@@ -166,21 +154,16 @@ class LocalFileCache(Cache):
         content = self._compress_bytes(value) if self.use_compression else value
         tmp_path: str | None = None
         try:
-            # flush + fsync guarantee the bytes hit disk before the atomic rename.
             with tempfile.NamedTemporaryFile("wb", dir=self.root_path, delete=False) as tmp_file:
                 tmp_path = tmp_file.name
                 tmp_file.write(content)
                 tmp_file.flush()
                 os.fsync(tmp_file.fileno())
             os.replace(tmp_path, key_path)  # noqa: PTH105 - atomic same-dir replace
-            tmp_path = None  # renamed into place; nothing for the finally to clean up
+            tmp_path = None
         finally:
-            # delete=False: drop the temp file if anything before the rename is
-            # interrupted -- including BaseException (e.g. KeyboardInterrupt).
             if tmp_path is not None:
                 Path(tmp_path).unlink(missing_ok=True)
-        # Enforce the size bound lazily here (moved out of __init__ to avoid an
-        # O(n*log n) scan on construction).
         self.shrink_to_fit_max_size()
 
     def _set(self, key: str, value: str) -> None:

--- a/hyperion/adapters/cache/filesystem.py
+++ b/hyperion/adapters/cache/filesystem.py
@@ -6,6 +6,7 @@ gracefully when ``python-snappy`` is not installed.
 
 from __future__ import annotations
 
+import os
 import tempfile
 import time
 from collections.abc import Iterator
@@ -17,6 +18,11 @@ from hyperion.log import get_logger
 from hyperion.ports.cache import DEFAULT_TTL_SECONDS, Cache, CacheKeyOpenMode
 
 DEFAULT_LOCAL_FILE_CACHE_MAX_SIZE = 256 * (1024**2)
+
+# Stable, namespaced default root under the system temp dir. Using a fixed
+# subdir (instead of tempfile.mkdtemp()) means default-constructed instances
+# share one reusable directory rather than leaking a fresh tmp dir each time.
+DEFAULT_LOCAL_FILE_CACHE_DIRNAME = "hyperion-cache"
 
 logger = get_logger("cache")
 
@@ -34,7 +40,10 @@ class LocalFileCache(Cache):
         use_compression: bool = True,
     ) -> None:
         super().__init__(prefix, hash_keys, default_ttl)
-        self.root_path = root_path or Path(tempfile.mkdtemp())
+        # A stable namespaced dir under the system temp dir is reused across
+        # instances/processes -- unlike tempfile.mkdtemp(), which leaked a
+        # fresh, never-cleaned-up directory per default-constructed instance.
+        self.root_path = root_path or (Path(tempfile.gettempdir()) / DEFAULT_LOCAL_FILE_CACHE_DIRNAME)
         if self.root_path.exists() and not self.root_path.is_dir():
             raise ValueError(f"Given local cache path ({self.root_path.as_posix()}) is not a directory.")
         self.use_compression = use_compression
@@ -43,7 +52,9 @@ class LocalFileCache(Cache):
         logger.info(f"Initialized LocalFileCache in {self.root_path.as_posix()}.", root_path=self.root_path.as_posix())
         if not hash_keys:
             logger.warning("When using filesystem cache, it is recommended to hash keys.")
-        self.shrink_to_fit_max_size()
+        # Size enforcement is deferred to write time (see _perform_set). Doing a
+        # full O(n*log n) sorted dir scan in __init__ blocked construction for
+        # large caches.
 
     def _assert_root_path(self) -> None:
         self.root_path.mkdir(parents=True, exist_ok=True)
@@ -85,13 +96,18 @@ class LocalFileCache(Cache):
         key_path = self._key_path(key)
         key_path.touch(exist_ok=True)
         if mode == "str":
-            with key_path.open("a+") as file:
+            with key_path.open("r+") as file:
                 file.seek(0)
                 yield file
+                # r+ does not truncate: a shorter rewrite ("hello" -> "hi")
+                # would otherwise leave trailing bytes ("hilo"). Truncate at
+                # the caller's final position to honour the overwrite contract.
+                file.truncate(file.tell())
         elif mode == "bytes":
-            with key_path.open("a+b") as file:
+            with key_path.open("r+b") as file:
                 file.seek(0)
                 yield file
+                file.truncate(file.tell())
         else:
             raise ValueError(f"Unsupported open mode {mode!r} - 'str' or 'bytes' are supported.")
         if not key_path.stat().st_size:
@@ -102,6 +118,9 @@ class LocalFileCache(Cache):
         if not self.max_size or self.max_size < 0:
             return
         total_size = self.get_total_size()
+        if total_size <= self.max_size:
+            # Cheap O(n) stat sum already done; skip the O(n*log n) sort+evict.
+            return
         keys_ordered = sorted(self.root_path.iterdir(), key=lambda key: key.stat().st_mtime)
         while total_size > self.max_size:
             key_path = keys_ordered.pop(0)
@@ -145,7 +164,24 @@ class LocalFileCache(Cache):
         if isinstance(value, str):
             value = value.encode("utf-8")
         content = self._compress_bytes(value) if self.use_compression else value
-        key_path.write_bytes(content)
+        tmp_path: str | None = None
+        try:
+            # flush + fsync guarantee the bytes hit disk before the atomic rename.
+            with tempfile.NamedTemporaryFile("wb", dir=self.root_path, delete=False) as tmp_file:
+                tmp_path = tmp_file.name
+                tmp_file.write(content)
+                tmp_file.flush()
+                os.fsync(tmp_file.fileno())
+            os.replace(tmp_path, key_path)  # noqa: PTH105 - atomic same-dir replace
+            tmp_path = None  # renamed into place; nothing for the finally to clean up
+        finally:
+            # delete=False: drop the temp file if anything before the rename is
+            # interrupted -- including BaseException (e.g. KeyboardInterrupt).
+            if tmp_path is not None:
+                Path(tmp_path).unlink(missing_ok=True)
+        # Enforce the size bound lazily here (moved out of __init__ to avoid an
+        # O(n*log n) scan on construction).
+        self.shrink_to_fit_max_size()
 
     def _set(self, key: str, value: str) -> None:
         return self._perform_set(key, value)

--- a/hyperion/adapters/storage/filesystem.py
+++ b/hyperion/adapters/storage/filesystem.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import datetime
 import hashlib
+import shutil
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -19,9 +20,7 @@ from hyperion.ports.storage import ObjectAttributes, ObjectNotFoundError
 
 logger = get_logger("adapters.storage.filesystem")
 
-
-def _to_bytes(data: bytes | IO[bytes]) -> bytes:
-    return data if isinstance(data, bytes) else data.read()
+_HASH_CHUNK_SIZE = 64 * 1024  # 64 KiB read window for streaming md5.
 
 
 class FilesystemStorage:
@@ -40,7 +39,13 @@ class FilesystemStorage:
         target = self._resolve(key)
         logger.debug("Writing object to disk.", key=key, path=target.as_posix())
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_bytes(_to_bytes(data))
+        if isinstance(data, bytes):
+            target.write_bytes(data)
+        else:
+            # Stream the caller's file-like input without materializing it
+            # in memory; the caller owns and closes their stream (#147/#148).
+            with target.open("wb") as fh:
+                shutil.copyfileobj(data, fh)
 
     async def put_async(self, key: str, data: bytes | IO[bytes]) -> None:
         self.put(key, data)
@@ -82,8 +87,12 @@ class FilesystemStorage:
             stat = target.stat()
         except FileNotFoundError as error:
             raise ObjectNotFoundError(key) from error
+        digest = hashlib.md5(usedforsecurity=False)
+        with target.open("rb") as fh:
+            for chunk in iter(lambda: fh.read(_HASH_CHUNK_SIZE), b""):
+                digest.update(chunk)
         return ObjectAttributes(
-            etag=hashlib.md5(target.read_bytes(), usedforsecurity=False).hexdigest(),
+            etag=digest.hexdigest(),
             size=stat.st_size,
             last_modified=datetime.datetime.fromtimestamp(stat.st_mtime, tz=datetime.UTC),
         )

--- a/hyperion/adapters/storage/filesystem.py
+++ b/hyperion/adapters/storage/filesystem.py
@@ -20,7 +20,7 @@ from hyperion.ports.storage import ObjectAttributes, ObjectNotFoundError
 
 logger = get_logger("adapters.storage.filesystem")
 
-_HASH_CHUNK_SIZE = 64 * 1024  # 64 KiB read window for streaming md5.
+_HASH_CHUNK_SIZE = 64 * 1024
 
 
 class FilesystemStorage:
@@ -42,8 +42,6 @@ class FilesystemStorage:
         if isinstance(data, bytes):
             target.write_bytes(data)
         else:
-            # Stream the caller's file-like input without materializing it
-            # in memory; the caller owns and closes their stream (#147/#148).
             with target.open("wb") as fh:
                 shutil.copyfileobj(data, fh)
 

--- a/hyperion/adapters/storage/s3.py
+++ b/hyperion/adapters/storage/s3.py
@@ -69,13 +69,11 @@ class S3Storage:
             raise
 
     async def put_async(self, key: str, data: bytes | IO[bytes]) -> None:
-        # Mirror sync put() ownership: only the BytesIO we create here is
-        # ours to close; a caller-supplied IO[bytes] passes straight
-        # through and is never closed by this adapter (issue #148).
         if isinstance(data, bytes):
             with BytesIO(data) as fileobj:
                 await self._upload_fileobj_async(key, fileobj)
         else:
+            # Caller-owned stream: passed through untouched, never closed here.
             await self._upload_fileobj_async(key, data)
 
     async def _upload_fileobj_async(self, key: str, fileobj: IO[bytes]) -> None:

--- a/hyperion/adapters/storage/s3.py
+++ b/hyperion/adapters/storage/s3.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from asyncio import Semaphore
 from collections.abc import AsyncIterator, Iterator
-from contextlib import ExitStack, asynccontextmanager, contextmanager
+from contextlib import asynccontextmanager, contextmanager
 from io import BytesIO
 from typing import IO, TYPE_CHECKING, cast
 
@@ -69,15 +69,22 @@ class S3Storage:
             raise
 
     async def put_async(self, key: str, data: bytes | IO[bytes]) -> None:
-        with ExitStack() as stack:
-            fileobj: IO[bytes] = BytesIO(data) if isinstance(data, bytes) else data
-            stack.callback(fileobj.close)
-            async with self._semaphore(), self._aio_session.client("s3") as s3:
-                try:
-                    await s3.upload_fileobj(fileobj, self._bucket, self._full_key(key))
-                except botocore.exceptions.ClientError:
-                    logger.error("Error when uploading object to S3.", bucket=self._bucket, key=key)
-                    raise
+        # Mirror sync put() ownership: only the BytesIO we create here is
+        # ours to close; a caller-supplied IO[bytes] passes straight
+        # through and is never closed by this adapter (issue #148).
+        if isinstance(data, bytes):
+            with BytesIO(data) as fileobj:
+                await self._upload_fileobj_async(key, fileobj)
+        else:
+            await self._upload_fileobj_async(key, data)
+
+    async def _upload_fileobj_async(self, key: str, fileobj: IO[bytes]) -> None:
+        async with self._semaphore(), self._aio_session.client("s3") as s3:
+            try:
+                await s3.upload_fileobj(fileobj, self._bucket, self._full_key(key))
+            except botocore.exceptions.ClientError:
+                logger.error("Error when uploading object to S3.", bucket=self._bucket, key=key)
+                raise
 
     def get(self, key: str) -> bytes:
         try:

--- a/hyperion/catalog/catalog.py
+++ b/hyperion/catalog/catalog.py
@@ -6,7 +6,7 @@ import re
 import shutil
 import tempfile
 from collections.abc import Iterable, Iterator, Mapping
-from contextlib import ExitStack, contextmanager
+from contextlib import contextmanager
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, BinaryIO, ClassVar, Generic, TypeAlias, TypeVar, cast
 from uuid import uuid4
@@ -227,22 +227,48 @@ class Catalog:
 
         return Catalog(storage=composition.default_storage())
 
+    def _serialize_asset_to_tempfile(
+        self, asset: AssetProtocol, data: Iterable[dict[str, Any]], schema_path: str | None = None
+    ) -> Path:
+        """Serialize ``data`` for ``asset`` into a freshly created temp file.
+
+        Returns the path to an undeleted ``NamedTemporaryFile``; the caller owns
+        its lifecycle and MUST delete it (see ``_prepare_asset_storage`` /
+        ``store_asset_async``). All blocking work (schema fetch, avro encode,
+        disk I/O) happens here so it can be run via ``asyncio.to_thread``.
+        """
+        schema = (
+            self.schema_store.get_asset_schema(asset)
+            if schema_path is None
+            else self.schema_store.get_schema_from_path(schema_path)
+        )
+        # delete=False: the file must outlive this function so the caller can
+        # stream it to storage; the caller guarantees deletion in a finally.
+        file = tempfile.NamedTemporaryFile("+wb", delete=False)  # noqa: SIM115
+        path = Path(file.name)
+        try:
+            logger.info("Pouring asset into a temporary file.", asset=asset, file=path.as_posix())
+            self._serializer.write(file, schema, data, asset.to_metadata())
+            logger.info("Avro file was created successfully.", path=path.as_posix(), size=file.tell())
+        except BaseException:
+            file.close()
+            path.unlink(missing_ok=True)
+            raise
+        file.close()
+        return path
+
     @contextmanager
     def _prepare_asset_storage(
         self, asset: AssetProtocol, data: Iterable[dict[str, Any]], schema_path: str | None = None
     ) -> Iterator[IO[bytes]]:
-        with tempfile.NamedTemporaryFile("+wb") as file:
-            schema = (
-                self.schema_store.get_asset_schema(asset)
-                if schema_path is None
-                else self.schema_store.get_schema_from_path(schema_path)
-            )
-            path = Path(file.name)
-            logger.info("Pouring asset into a temporary file.", asset=asset, file=path.as_posix())
-            self._serializer.write(file, schema, data, asset.to_metadata())
-            logger.info("Avro file was created successfully.", path=path.as_posix(), size=file.tell())
-            file.seek(0)
-            yield file
+        path = self._serialize_asset_to_tempfile(asset, data, schema_path)
+        try:
+            with path.open("rb") as file:
+                yield file
+        finally:
+            # delete=False in the worker: this context manager owns deletion,
+            # and must drop the temp file even on Exception/BaseException.
+            path.unlink(missing_ok=True)
 
     async def store_asset_async(
         self, asset: AssetProtocol, data: Iterable[dict[str, Any]], notify: bool = True, schema_path: str | None = None
@@ -255,9 +281,15 @@ class Catalog:
             notify (bool, optional): Whether to send a notification. Defaults to True.
         """
         logger.info("Preparing asset storage.", asset=asset)
-        with ExitStack() as stack:
-            file = stack.enter_context(await asyncio.to_thread(self._prepare_asset_storage, asset, data, schema_path))
-            await self._resolve_storage(asset).put_async(asset.get_path(), file)
+        prepared_path = await asyncio.to_thread(self._serialize_asset_to_tempfile, asset, data, schema_path)
+        try:
+            with prepared_path.open("rb") as file:
+                await self._resolve_storage(asset).put_async(asset.get_path(), file)
+        finally:
+            # The worker created the temp file with delete=False; this path owns
+            # its deletion and must drop it even on Exception/BaseException
+            # (e.g. an upload failure or cancellation).
+            prepared_path.unlink(missing_ok=True)
         if notify:
             self._notify_asset_arrival(asset, schema_path=schema_path)
 

--- a/hyperion/catalog/catalog.py
+++ b/hyperion/catalog/catalog.py
@@ -610,6 +610,24 @@ class AssetRepartitioner(Generic[RepartitionableAsset]):
         self._state[partition_date] = handler
         return handler
 
+    def _write_records(self, data: Iterable[dict[str, Any]]) -> None:
+        """Drain ``data`` into per-partition streaming writers (blocking).
+
+        Runs the synchronous fastavro per-record writes off the event loop in
+        one ``asyncio.to_thread`` hop. Partitioning logic and ``_get_handler``
+        state semantics are unchanged.
+        """
+        for record in data:
+            timestamp = record.get(self.date_attribute)
+            if not isinstance(timestamp, datetime.datetime):
+                raise ValueError(
+                    f"Asset {self.asset!r} cannot be repartitioned using date attribute "
+                    f"{self.date_attribute!r} - it is not a valid datetime."
+                )
+            partition_date = truncate_datetime(timestamp, self.granularity)
+            _, __, writer = self._get_handler(partition_date)
+            writer.write(record)
+
     async def repartition(self, data: Iterable[dict[str, Any]] | None = None) -> None:
         """Repartition the asset.
 
@@ -622,21 +640,12 @@ class AssetRepartitioner(Generic[RepartitionableAsset]):
         """
         data = data or self.catalog.retrieve_asset(self.asset)
         with self:
-            for record in data:
-                timestamp = record.get(self.date_attribute)
-                if not isinstance(timestamp, datetime.datetime):
-                    raise ValueError(
-                        f"Asset {self.asset!r} cannot be repartitioned using date attribute "
-                        f"{self.date_attribute!r} - it is not a valid datetime."
-                    )
-                partition_date = truncate_datetime(timestamp, self.granularity)
-                _, __, writer = self._get_handler(partition_date)
-                writer.write(record)
+            await asyncio.to_thread(self._write_records, data)
             logger.info("Finished creating partitioned avro files.")
 
             async with AsyncTaskQueue[None](maxsize=5) as queue:
                 async for file, asset, writer in aiter_any(self._state.values()):
                     logger.info("Dumping and uploading asset from temporary file.", asset=asset, path=file.name)
-                    writer.dump()
+                    await asyncio.to_thread(writer.dump)
                     file.seek(0)
                     await queue.add_task(self.catalog._resolve_storage(asset).put_async(asset.get_path(), file))

--- a/hyperion/catalog/catalog.py
+++ b/hyperion/catalog/catalog.py
@@ -230,20 +230,15 @@ class Catalog:
     def _serialize_asset_to_tempfile(
         self, asset: AssetProtocol, data: Iterable[dict[str, Any]], schema_path: str | None = None
     ) -> Path:
-        """Serialize ``data`` for ``asset`` into a freshly created temp file.
+        """Serialize ``data`` for ``asset`` into a closed temp file and return its path.
 
-        Returns the path to an undeleted ``NamedTemporaryFile``; the caller owns
-        its lifecycle and MUST delete it (see ``_prepare_asset_storage`` /
-        ``store_asset_async``). All blocking work (schema fetch, avro encode,
-        disk I/O) happens here so it can be run via ``asyncio.to_thread``.
+        The caller owns the returned path and is responsible for deleting it.
         """
         schema = (
             self.schema_store.get_asset_schema(asset)
             if schema_path is None
             else self.schema_store.get_schema_from_path(schema_path)
         )
-        # delete=False: the file must outlive this function so the caller can
-        # stream it to storage; the caller guarantees deletion in a finally.
         file = tempfile.NamedTemporaryFile("+wb", delete=False)  # noqa: SIM115
         path = Path(file.name)
         try:
@@ -266,8 +261,6 @@ class Catalog:
             with path.open("rb") as file:
                 yield file
         finally:
-            # delete=False in the worker: this context manager owns deletion,
-            # and must drop the temp file even on Exception/BaseException.
             path.unlink(missing_ok=True)
 
     async def store_asset_async(
@@ -286,9 +279,6 @@ class Catalog:
             with prepared_path.open("rb") as file:
                 await self._resolve_storage(asset).put_async(asset.get_path(), file)
         finally:
-            # The worker created the temp file with delete=False; this path owns
-            # its deletion and must drop it even on Exception/BaseException
-            # (e.g. an upload failure or cancellation).
             prepared_path.unlink(missing_ok=True)
         if notify:
             self._notify_asset_arrival(asset, schema_path=schema_path)
@@ -611,12 +601,7 @@ class AssetRepartitioner(Generic[RepartitionableAsset]):
         return handler
 
     def _write_records(self, data: Iterable[dict[str, Any]]) -> None:
-        """Drain ``data`` into per-partition streaming writers (blocking).
-
-        Runs the synchronous fastavro per-record writes off the event loop in
-        one ``asyncio.to_thread`` hop. Partitioning logic and ``_get_handler``
-        state semantics are unchanged.
-        """
+        """Drain ``data`` into per-partition streaming writers (blocking)."""
         for record in data:
             timestamp = record.get(self.date_attribute)
             if not isinstance(timestamp, datetime.datetime):

--- a/tests/adapters/storage/test_storage.py
+++ b/tests/adapters/storage/test_storage.py
@@ -6,6 +6,7 @@ Mirrors the parametrize-over-backends pattern of
 so the same suite runs identically against memory / filesystem / s3.
 """
 
+import hashlib
 import uuid
 from io import BytesIO
 from pathlib import Path
@@ -17,6 +18,8 @@ from hyperion.adapters.storage.filesystem import FilesystemStorage
 from hyperion.adapters.storage.memory import MemoryStorage
 from hyperion.adapters.storage.s3 import S3Storage
 from hyperion.ports.storage import ObjectNotFoundError, StoragePort
+
+_LARGE_PAYLOAD = b"hyperion-storage-stream-test\n" * 200_000  # ~5.6 MiB
 
 
 @pytest.fixture
@@ -151,3 +154,19 @@ async def test_s3_put_async_does_not_close_caller_stream() -> None:
     assert storage.get("stream/obj.bin") == b"caller-owned-stream"
 
     await storage.put_async("bytes/obj.bin", b"async-bytes")
+    assert storage.get("bytes/obj.bin") == b"async-bytes"
+
+
+def test_filesystem_put_streams_large_filelike(filesystem_storage: FilesystemStorage) -> None:
+    filesystem_storage.put("big/obj.bin", BytesIO(_LARGE_PAYLOAD))
+    assert filesystem_storage.get("big/obj.bin") == _LARGE_PAYLOAD
+
+
+def test_filesystem_get_attributes_etag_correct_for_large_payload(
+    filesystem_storage: FilesystemStorage,
+) -> None:
+    filesystem_storage.put("big/obj.bin", BytesIO(_LARGE_PAYLOAD))
+    attrs = filesystem_storage.get_attributes("big/obj.bin")
+    expected_etag = hashlib.md5(_LARGE_PAYLOAD, usedforsecurity=False).hexdigest()
+    assert attrs.etag == expected_etag
+    assert attrs.size == len(_LARGE_PAYLOAD)

--- a/tests/adapters/storage/test_storage.py
+++ b/tests/adapters/storage/test_storage.py
@@ -137,3 +137,17 @@ def test_s3_prefix_is_transparent_to_callers() -> None:
     assert list(storage.iter_keys("data/")) == ["data/obj.bin"]
     raw_keys = [obj["Key"] for obj in boto3.client("s3").list_objects_v2(Bucket=bucket)["Contents"]]
     assert raw_keys == ["tenant-a/data/obj.bin"]
+
+
+@pytest.mark.usefixtures("_moto_server")
+async def test_s3_put_async_does_not_close_caller_stream() -> None:
+    bucket = f"hyperion-storage-async-{uuid.uuid4().hex}"
+    boto3.client("s3", region_name="us-east-1").create_bucket(Bucket=bucket)
+    storage = S3Storage(bucket)
+
+    buf = BytesIO(b"caller-owned-stream")
+    await storage.put_async("stream/obj.bin", buf)
+    assert not buf.closed  # issue #148: caller-owned stream must stay open
+    assert storage.get("stream/obj.bin") == b"caller-owned-stream"
+
+    await storage.put_async("bytes/obj.bin", b"async-bytes")

--- a/tests/adapters/storage/test_storage.py
+++ b/tests/adapters/storage/test_storage.py
@@ -19,7 +19,7 @@ from hyperion.adapters.storage.memory import MemoryStorage
 from hyperion.adapters.storage.s3 import S3Storage
 from hyperion.ports.storage import ObjectNotFoundError, StoragePort
 
-_LARGE_PAYLOAD = b"hyperion-storage-stream-test\n" * 200_000  # ~5.6 MiB
+_LARGE_PAYLOAD = b"hyperion-storage-stream-test\n" * 200_000
 
 
 @pytest.fixture
@@ -150,7 +150,7 @@ async def test_s3_put_async_does_not_close_caller_stream() -> None:
 
     buf = BytesIO(b"caller-owned-stream")
     await storage.put_async("stream/obj.bin", buf)
-    assert not buf.closed  # issue #148: caller-owned stream must stay open
+    assert not buf.closed
     assert storage.get("stream/obj.bin") == b"caller-owned-stream"
 
     await storage.put_async("bytes/obj.bin", b"async-bytes")

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -647,6 +647,106 @@ class TestStoreAssetAsync:
         assert len(queue._messages) == 1
 
 
+class _SlowSerializer:
+    SERIALIZE_SECONDS = 0.3
+
+    def __init__(self) -> None:
+        self.write_thread: int | None = None
+
+    def write(self, fp: Any, schema: dict[str, Any], records: Any, metadata: dict[str, str]) -> None:
+        import threading
+        import time
+
+        self.write_thread = threading.get_ident()
+        time.sleep(self.SERIALIZE_SECONDS)
+        fastavro.writer(fp, schema=schema, records=list(records), metadata=metadata)
+
+    def read(self, fp: Any) -> Any:
+        # Delegates to fastavro so the existing-style round-trip assertion can
+        # decode what write() produced (mirrors AvroSerializer.read).
+        yield from fastavro.reader(fp)
+
+
+class TestStoreAsyncDoesNotBlockLoop:
+    async def test_event_loop_free_during_serialization(self, test_tmp_dir: Path) -> None:
+        import asyncio
+        import threading
+
+        schema = {"type": "record", "name": "NoBlock", "fields": [{"name": "id", "type": "string"}]}
+        schema_path = test_tmp_dir / "schemas" / "noblock.v1.avro.json"
+        schema_path.write_text(json.dumps(schema))
+
+        serializer = _SlowSerializer()
+        catalog = Catalog(
+            storage=MemoryStorage(),
+            schema_store=LocalSchemaStore(test_tmp_dir / "schemas"),
+            queue=InMemoryQueue(),
+            serializer=serializer,  # type: ignore[arg-type]
+        )
+        asset = DataLakeAsset("noblock", utcnow())
+        data = [{"id": "a"}, {"id": "b"}]
+
+        ticks = 0
+        stop = False
+
+        async def heartbeat() -> None:
+            nonlocal ticks
+            while not stop:
+                await asyncio.sleep(0.01)
+                ticks += 1
+
+        hb = asyncio.create_task(heartbeat())
+        await catalog.store_asset_async(asset, data, notify=True, schema_path=schema_path.as_posix())
+        stop = True
+        await hb
+
+        assert serializer.write_thread is not None
+        assert serializer.write_thread != threading.get_ident(), "serialize ran on the event-loop thread"
+        assert ticks >= 10, f"event loop was blocked during serialization (only {ticks} ticks)"
+        assert list(catalog.retrieve_asset(asset)) == data
+        queue = catalog.queue
+        assert isinstance(queue, InMemoryQueue)
+        assert len(queue._messages) == 1
+
+
+class TestStoreAsyncTempFileLifecycle:
+    async def test_no_tempfile_leak_on_success(self, test_tmp_dir: Path) -> None:
+        import tempfile as _tempfile
+
+        schema = {"type": "record", "name": "Leak", "fields": [{"name": "id", "type": "string"}]}
+        schema_path = test_tmp_dir / "schemas" / "leak-ok.v1.avro.json"
+        schema_path.write_text(json.dumps(schema))
+        tmp_root = Path(_tempfile.gettempdir())
+        before = set(tmp_root.iterdir())
+        catalog = Catalog(
+            storage=MemoryStorage(),
+            schema_store=LocalSchemaStore(test_tmp_dir / "schemas"),
+            queue=InMemoryQueue(),
+        )
+        asset = DataLakeAsset("leak-ok", utcnow())
+        await catalog.store_asset_async(asset, [{"id": "a"}], notify=False, schema_path=schema_path.as_posix())
+        assert set(tmp_root.iterdir()) - before == set()
+        assert list(catalog.retrieve_asset(asset)) == [{"id": "a"}]
+
+    async def test_tempfile_removed_and_error_propagates_on_bad_data(self, test_tmp_dir: Path) -> None:
+        import tempfile as _tempfile
+
+        schema = {"type": "record", "name": "BadAsync", "fields": [{"name": "id", "type": "string"}]}
+        schema_path = test_tmp_dir / "schemas" / "leak-bad.v1.avro.json"
+        schema_path.write_text(json.dumps(schema))
+        tmp_root = Path(_tempfile.gettempdir())
+        before = set(tmp_root.iterdir())
+        catalog = Catalog(
+            storage=MemoryStorage(),
+            schema_store=LocalSchemaStore(test_tmp_dir / "schemas"),
+            queue=InMemoryQueue(),
+        )
+        asset = DataLakeAsset("leak-bad", utcnow())
+        with pytest.raises(fastavro.validation.ValidationError):
+            await catalog.store_asset_async(asset, [{"not_id": 123}], notify=True, schema_path=schema_path.as_posix())
+        assert set(tmp_root.iterdir()) - before == set()
+
+
 class TestRepartition:
     async def test_repartition_data_lake_asset_by_day(self, tmp_path: Path) -> None:
         schema_dir = tmp_path / "schemas" / "data_lake"

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -663,8 +663,6 @@ class _SlowSerializer:
         fastavro.writer(fp, schema=schema, records=list(records), metadata=metadata)
 
     def read(self, fp: Any) -> Any:
-        # Delegates to fastavro so the existing-style round-trip assertion can
-        # decode what write() produced (mirrors AvroSerializer.read).
         yield from fastavro.reader(fp)
 
 
@@ -855,7 +853,6 @@ class TestRepartitionDoesNotBlockLoop:
         assert serializer.write_thread != threading.get_ident(), "writer.write ran on the event-loop thread"
         assert ticks >= 10, f"event loop was blocked during repartition writes (only {ticks} ticks)"
 
-        # Behavioural equivalence: same partitions/rows as the canonical test.
         partitions = sorted(catalog.iter_datalake_partitions("repart"), key=lambda asset: asset.date)
         assert [p.date for p in partitions] == [
             datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC),

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -11,6 +11,7 @@ import boto3
 import fastavro
 import pytest
 
+from hyperion.adapters.serialization.avro import AvroSerializer, AvroStreamWriter
 from hyperion.adapters.storage.filesystem import FilesystemStorage
 from hyperion.adapters.storage.memory import MemoryStorage
 from hyperion.adapters.storage.s3 import S3Storage
@@ -778,3 +779,87 @@ class TestRepartition:
         assert {row["id"] for row in first_day} == {"a", "b"}
         second_day = list(catalog.retrieve_asset(partitions[1]))
         assert {row["id"] for row in second_day} == {"c"}
+
+
+class _SlowStreamWriter:
+    """Wraps a real fastavro stream writer; ``write`` blocks like a heavy encode."""
+
+    WRITE_SECONDS = 0.15
+
+    def __init__(self, inner: AvroStreamWriter, owner: "_SlowStreamingSerializer") -> None:
+        self._inner = inner
+        self._owner = owner
+
+    def write(self, record: dict[str, Any]) -> None:
+        import threading
+        import time
+
+        self._owner.write_thread = threading.get_ident()
+        time.sleep(self.WRITE_SECONDS)
+        self._inner.write(record)
+
+    def dump(self) -> None:
+        self._inner.dump()
+
+
+class _SlowStreamingSerializer(AvroSerializer):
+    """Real AvroSerializer whose streaming writer's per-record write is slow."""
+
+    def __init__(self) -> None:
+        self.write_thread: int | None = None
+
+    def streaming_writer(self, fp: Any, schema: dict[str, Any], metadata: dict[str, str]) -> AvroStreamWriter:
+        return _SlowStreamWriter(super().streaming_writer(fp, schema, metadata), self)
+
+
+class TestRepartitionDoesNotBlockLoop:
+    async def test_event_loop_free_during_repartition_writes(self, tmp_path: Path) -> None:
+        import asyncio
+        import threading
+
+        schema_dir = tmp_path / "schemas" / "data_lake"
+        schema_dir.mkdir(parents=True)
+        (schema_dir / "repart.v1.avro.json").write_text(json.dumps(_TS_SCHEMA))
+
+        serializer = _SlowStreamingSerializer()
+        catalog = Catalog(
+            storage=MemoryStorage(),
+            schema_store=LocalSchemaStore(tmp_path / "schemas"),
+            queue=InMemoryQueue(),
+            serializer=serializer,
+        )
+        day_one = datetime.datetime(2025, 1, 1, 8, tzinfo=datetime.UTC)
+        day_two = datetime.datetime(2025, 1, 2, 9, tzinfo=datetime.UTC)
+        records = [
+            {"id": "a", "timestamp": day_one},
+            {"id": "b", "timestamp": day_one.replace(hour=20)},
+            {"id": "c", "timestamp": day_two},
+        ]
+        source_asset = DataLakeAsset("repart", day_one)
+
+        ticks = 0
+        stop = False
+
+        async def heartbeat() -> None:
+            nonlocal ticks
+            while not stop:
+                await asyncio.sleep(0.01)
+                ticks += 1
+
+        hb = asyncio.create_task(heartbeat())
+        await catalog.repartition(source_asset, "d", date_attribute="timestamp", data=records)
+        stop = True
+        await hb
+
+        assert serializer.write_thread is not None
+        assert serializer.write_thread != threading.get_ident(), "writer.write ran on the event-loop thread"
+        assert ticks >= 10, f"event loop was blocked during repartition writes (only {ticks} ticks)"
+
+        # Behavioural equivalence: same partitions/rows as the canonical test.
+        partitions = sorted(catalog.iter_datalake_partitions("repart"), key=lambda asset: asset.date)
+        assert [p.date for p in partitions] == [
+            datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC),
+            datetime.datetime(2025, 1, 2, tzinfo=datetime.UTC),
+        ]
+        assert {row["id"] for row in catalog.retrieve_asset(partitions[0])} == {"a", "b"}
+        assert {row["id"] for row in catalog.retrieve_asset(partitions[1])} == {"c"}

--- a/tests/infrastructure/test_cache.py
+++ b/tests/infrastructure/test_cache.py
@@ -234,10 +234,6 @@ def test_cache_stats(instance: Cache) -> None:
 
 @pytest.mark.parametrize("local_file_cache_maxsize", [1024], indirect=True)
 def test_local_file_cache_cleanup(local_file_cache_maxsize: LocalFileCache) -> None:
-    # An entry larger than max_size is evicted by size enforcement. Enforcement
-    # now runs eagerly at write time (deferred out of __init__ into
-    # _perform_set), so the oversized write is already gone after set_bytes;
-    # the explicit shrink call is an idempotent re-check.
     local_file_cache_maxsize.set_bytes("large", os.urandom(4096))
     assert not local_file_cache_maxsize.hit("large")
     local_file_cache_maxsize.shrink_to_fit_max_size()
@@ -273,12 +269,9 @@ def test_cache_stats_subtraction() -> None:
 def test_local_file_cache_eviction_oldest_first(
     local_file_cache_maxsize: LocalFileCache,
 ) -> None:
-    # Three 1024-byte entries; max_size=3000 forces at least one eviction. The
-    # oldest (lowest mtime) entry must be evicted first. Size enforcement now
-    # runs eagerly inside _perform_set, so the third write itself triggers the
-    # eviction -- fix each entry's mtime right after it is written (before the
-    # next write) so the ordering is deterministic and independent of
-    # filesystem time resolution.
+    # Three 1024-byte entries with max_size=3000; the oldest (lowest mtime)
+    # must be evicted first. Each entry's mtime is pinned right after it is
+    # written so the order is independent of filesystem time resolution.
     cache = local_file_cache_maxsize
     now = time()
 
@@ -363,12 +356,6 @@ def test_dynamodb_cache_clear_paginates_all_pages(
 def test_open_overwrite_shorter_leaves_no_trailing_bytes(
     local_file_cache_no_compression: LocalFileCache,
 ) -> None:
-    # Regression for #156: rewriting a key via open() with a shorter value
-    # must fully replace it. Append-mode (the old bug) appended; r+ without
-    # truncate would leave trailing bytes ("hello" -> "hi" => "hilo"). Scoped
-    # to the no-compression LocalFileCache -- the only path Edit 4 fixes; the
-    # shared base _open (compression on / DynamoDB / InMemory) persists the
-    # whole buffer via getvalue() and is governed by read-only ports/cache.py.
     instance = local_file_cache_no_compression
     instance.set("overwrite-str", "hello")
     with instance.open("overwrite-str", "str") as file:
@@ -389,8 +376,6 @@ def test_local_file_cache_set_cleans_up_temp_file_on_error(
     local_file_cache_no_compression: LocalFileCache,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Regression for #156: a crash mid-write (fsync failure) must leave neither
-    # a value file nor a stranded NamedTemporaryFile in the cache root.
     cache = local_file_cache_no_compression
     root = cache.root_path
 
@@ -407,7 +392,6 @@ def test_local_file_cache_set_cleans_up_temp_file_on_error(
 def test_local_file_cache_default_root_is_stable_and_no_scan_on_init(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Regression for #157.
     def _explode_mkdtemp(*_args: object, **_kwargs: object) -> str:
         raise AssertionError("default construction must not call tempfile.mkdtemp()")
 

--- a/tests/infrastructure/test_cache.py
+++ b/tests/infrastructure/test_cache.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from base64 import b64encode
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -8,6 +9,7 @@ from time import sleep, time
 import boto3
 import pytest
 
+from hyperion.adapters.cache.filesystem import DEFAULT_LOCAL_FILE_CACHE_DIRNAME
 from hyperion.infrastructure.cache import Cache, CacheStats, CachingError, DynamoDBCache, InMemoryCache, LocalFileCache
 
 DYNAMODB_TABLE = "test-table"
@@ -232,8 +234,12 @@ def test_cache_stats(instance: Cache) -> None:
 
 @pytest.mark.parametrize("local_file_cache_maxsize", [1024], indirect=True)
 def test_local_file_cache_cleanup(local_file_cache_maxsize: LocalFileCache) -> None:
+    # An entry larger than max_size is evicted by size enforcement. Enforcement
+    # now runs eagerly at write time (deferred out of __init__ into
+    # _perform_set), so the oversized write is already gone after set_bytes;
+    # the explicit shrink call is an idempotent re-check.
     local_file_cache_maxsize.set_bytes("large", os.urandom(4096))
-    assert local_file_cache_maxsize.hit("large")
+    assert not local_file_cache_maxsize.hit("large")
     local_file_cache_maxsize.shrink_to_fit_max_size()
     assert not local_file_cache_maxsize.hit("large")
 
@@ -268,23 +274,24 @@ def test_local_file_cache_eviction_oldest_first(
     local_file_cache_maxsize: LocalFileCache,
 ) -> None:
     # Three 1024-byte entries; max_size=3000 forces at least one eviction. The
-    # oldest (lowest mtime) entry must be evicted first. Use os.utime to fix
-    # mtimes explicitly so the test is independent of filesystem time resolution.
+    # oldest (lowest mtime) entry must be evicted first. Size enforcement now
+    # runs eagerly inside _perform_set, so the third write itself triggers the
+    # eviction -- fix each entry's mtime right after it is written (before the
+    # next write) so the ordering is deterministic and independent of
+    # filesystem time resolution.
     cache = local_file_cache_maxsize
+    now = time()
 
-    def _write_and_locate(key: str, value: bytes) -> Path:
+    def _write_and_set_mtime(key: str, value: bytes, mtime: float) -> Path:
         before = set(cache.root_path.iterdir())
         cache.set_bytes(key, value)
-        return (set(cache.root_path.iterdir()) - before).pop()
+        path = (set(cache.root_path.iterdir()) - before).pop()
+        os.utime(path, (mtime, mtime))
+        return path
 
-    oldest_path = _write_and_locate("oldest", os.urandom(1024))
-    middle_path = _write_and_locate("middle", os.urandom(1024))
-    newest_path = _write_and_locate("newest", os.urandom(1024))
-
-    now = time()
-    os.utime(oldest_path, (now - 200, now - 200))
-    os.utime(middle_path, (now - 100, now - 100))
-    os.utime(newest_path, (now, now))
+    _write_and_set_mtime("oldest", os.urandom(1024), now - 200)
+    _write_and_set_mtime("middle", os.urandom(1024), now - 100)
+    _write_and_set_mtime("newest", os.urandom(1024), now)
 
     cache.shrink_to_fit_max_size()
     assert not cache.hit("oldest")
@@ -351,3 +358,69 @@ def test_dynamodb_cache_clear_paginates_all_pages(
     assert sorted(deleted_keys) == sorted([item["key"] for item in page1_items + page2_items]), (
         "all items from both pages must be deleted"
     )
+
+
+def test_open_overwrite_shorter_leaves_no_trailing_bytes(
+    local_file_cache_no_compression: LocalFileCache,
+) -> None:
+    # Regression for #156: rewriting a key via open() with a shorter value
+    # must fully replace it. Append-mode (the old bug) appended; r+ without
+    # truncate would leave trailing bytes ("hello" -> "hi" => "hilo"). Scoped
+    # to the no-compression LocalFileCache -- the only path Edit 4 fixes; the
+    # shared base _open (compression on / DynamoDB / InMemory) persists the
+    # whole buffer via getvalue() and is governed by read-only ports/cache.py.
+    instance = local_file_cache_no_compression
+    instance.set("overwrite-str", "hello")
+    with instance.open("overwrite-str", "str") as file:
+        assert file.read() == "hello"
+        file.seek(0)
+        file.write("hi")
+    assert instance.get("overwrite-str") == "hi"
+
+    instance.set_bytes("overwrite-bytes", b"hello world")
+    with instance.open("overwrite-bytes", "bytes") as file:
+        assert file.read() == b"hello world"
+        file.seek(0)
+        file.write(b"hi")
+    assert instance.get_bytes("overwrite-bytes") == b"hi"
+
+
+def test_local_file_cache_set_cleans_up_temp_file_on_error(
+    local_file_cache_no_compression: LocalFileCache,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Regression for #156: a crash mid-write (fsync failure) must leave neither
+    # a value file nor a stranded NamedTemporaryFile in the cache root.
+    cache = local_file_cache_no_compression
+    root = cache.root_path
+
+    def _boom(_fd: int) -> None:
+        raise OSError("fsync failed")
+
+    monkeypatch.setattr("hyperion.adapters.cache.filesystem.os.fsync", _boom)
+    with pytest.raises(OSError, match="fsync failed"):
+        cache.set("atomic-key", "value")
+    assert list(root.iterdir()) == []
+    assert cache.get("atomic-key") is None
+
+
+def test_local_file_cache_default_root_is_stable_and_no_scan_on_init(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Regression for #157.
+    def _explode_mkdtemp(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("default construction must not call tempfile.mkdtemp()")
+
+    monkeypatch.setattr("hyperion.adapters.cache.filesystem.tempfile.mkdtemp", _explode_mkdtemp)
+
+    a = LocalFileCache(prefix="default-a")
+    b = LocalFileCache(prefix="default-b")
+    expected = Path(tempfile.gettempdir()) / DEFAULT_LOCAL_FILE_CACHE_DIRNAME
+    assert a.root_path == expected
+    assert b.root_path == expected
+
+    def _explode_shrink(self: LocalFileCache) -> None:
+        raise AssertionError("shrink_to_fit_max_size must not run during __init__")
+
+    monkeypatch.setattr(LocalFileCache, "shrink_to_fit_max_size", _explode_shrink)
+    LocalFileCache(prefix="default-c")


### PR DESCRIPTION
## Summary

Batched, low-risk follow-up bug & perf fixes for the storage/cache/catalog adapters — all surfaced by automated review during the v1.0.0 DDD refactor and deliberately deferred out of that no-behaviour-change epic. Each touches a disjoint set of files, so they are bundled into one PR to avoid serial merge/rebase/release cycles.

Five commits, one per concern:

| Commit | Issue | What |
|---|---|---|
| `fix(cache)` | #156, #157 | `LocalFileCache`: `_open` used append mode (`a+`) so rewrites appended instead of overwriting — now `r+`+truncate; `_perform_set` now writes atomically via tempfile+`fsync`+`os.replace` (mirrors the keyval `FilesystemStore` recipe). Default `root_path` no longer leaks a fresh `mkdtemp()` per instance (stable `<gettempdir()>/hyperion-cache`); the O(n·log n) dir scan is removed from `__init__` and deferred to write time with a cheap under-budget fast-path. |
| `fix(storage)` | #148 | `S3Storage.put_async` no longer closes a caller-supplied stream — only the internally-created `BytesIO` is closed, matching sync `put()` ownership semantics. |
| `perf(storage)` | #147 | `FilesystemStorage.put` streams file-like input via `shutil.copyfileobj` instead of buffering whole files; `get_attributes` hashes in 64 KiB chunks. Dead `_to_bytes` helper removed. No API/behaviour change; etag byte-for-byte identical. |
| `fix(catalog)` | #152 | `store_asset_async` actually runs avro serialization off the event loop: the heavy work moved into a plain `_serialize_asset_to_tempfile` worker invoked via `asyncio.to_thread` (the old `@contextmanager` only offloaded object construction). Sync `store_asset` shares the same worker. |
| `fix(catalog)` | #152 (related) | `AssetRepartitioner.repartition`: the per-record `writer.write` loop and each `writer.dump()` now run via `asyncio.to_thread` instead of blocking the loop. Partitioning/`_state`/`AsyncTaskQueue` flow unchanged. |

Closes #156
Closes #157
Closes #148
Closes #147
Closes #152

## Behaviour changes to note for review

- **#157 — default cache root is now shared & persistent.** Previously each default-constructed `LocalFileCache` got a private, ephemeral `mkdtemp()` dir (leaked, never cleaned). It is now a stable `<gettempdir()>/hyperion-cache` reused across instances/processes. No in-repo caller default-constructs `LocalFileCache` (all pass an explicit `root_path`), but external SDK consumers relying on per-instance isolation should be aware.
- **#157 — size enforcement timing moved.** `shrink_to_fit_max_size()` no longer runs in `__init__` (O(1) construction now); it runs at the end of every `_perform_set`. Two existing eviction tests were updated to assert the new eager-at-write timing — the invariants (oversized entry evicted; oldest-first) are unchanged.
- **#156 — `open()` now truncates to the caller's final cursor.** This is the intended `Cache` overwrite contract; code that (accidentally) relied on the old append behaviour will change.

## Testing

- Full suite on the integrated branch: **629 passed**, 0 failed (warnings are pre-existing DDD-shim deprecations).
- `ruff check`, `ruff format --check`, `mypy` (strict): clean on all changed files.
- `lint-imports`: 5/5 DDD contracts kept, 0 broken.
- New regression tests: overwrite-shrink + fsync-failure atomicity + stable-default-root (cache); caller-stream-stays-open via moto + large-payload streaming/etag (storage); event-loop-not-blocked heartbeat + tempfile-lifecycle + repartition off-loop (catalog).

## Release note

`fix:`/`perf:` are bumping commit types under this repo's commitizen config, so merging to `master` will auto-open a `release/1.0.2` PR. The five commits are intentionally kept separate (not squashed) so the auto-generated changelog stays accurate — merge with a merge/rebase strategy that preserves them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
