### PR TITLE
v2.0 wave 1: resource & contract fixes (#201 #202 #203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,34 @@ one project. Work through them in order:
   will see feature-store asset keys resolve to the corrected path (see *Catalog
   constructor change* above). Review any tooling that depended on the old path.
 
+## Unreleased — v2.0 (in progress)
+
+The v2.0 release is being assembled on the `v2.0` long-lived branch (see
+umbrella epic #193) and will land as one release PR once all waves are
+complete. Sections accumulate here per wave.
+
+### Wave 1 — resource & contract fixes
+
+#### Fix
+
+- **asyncutils**: handle plain callables in `aiter_any` (closes #203). The
+  signature advertised `Callable[[], Iterable[T] | AsyncIterable[T]]` but the
+  body only handled `isasyncgenfunction` / `isgeneratorfunction`, so a plain
+  `lambda: [1, 2, 3]` raised `TypeError`. One-hop callable branch added.
+- **catalog**: bound `AssetRepartitioner` open writers with an LRU (default
+  256, configurable via `max_open_writers`); raise on re-entered context
+  instead of silently clobbering `_state`; mirror the `BaseException`
+  tempfile-cleanup guard from `_serialize_asset_to_tempfile` (closes #202).
+  A 5-year hourly repartition no longer leaks ~43k file descriptors.
+
+#### Perf
+
+- **catalog**: keep small avro payloads in memory instead of the
+  write-close-reopen disk round-trip (closes #201). New
+  `spool_threshold_bytes` Catalog kwarg (default 8 MiB); payloads at or below
+  the threshold serialize to a `BytesIO` and upload from RAM, larger payloads
+  keep the existing on-disk path.
+
 ## 1.0.2 (2026-05-20)
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,9 +214,10 @@ complete. Sections accumulate here per wave.
 
 - **catalog**: keep small avro payloads in memory instead of the
   write-close-reopen disk round-trip (closes #201). New
-  `spool_threshold_bytes` Catalog kwarg (default 8 MiB); payloads at or below
-  the threshold serialize to a `BytesIO` and upload from RAM, larger payloads
-  keep the existing on-disk path.
+  `spool_threshold_bytes` Catalog kwarg (default 8 MiB); fastavro now writes
+  into a `tempfile.SpooledTemporaryFile` that stays in memory below the
+  threshold and rolls over to disk transparently during write — large
+  payloads no longer get double-buffered in RAM.
 
 ## 1.0.2 (2026-05-20)
 

--- a/hyperion/asyncutils.py
+++ b/hyperion/asyncutils.py
@@ -31,6 +31,14 @@ async def aiter_any(
         asyncgen = iter_async(iterable)
     elif inspect.isgeneratorfunction(iterable):
         asyncgen = iter_async(iterable())
+    elif callable(iterable):
+        result = iterable()
+        if inspect.isasyncgen(result) or isinstance(result, AsyncIterable):
+            asyncgen = result
+        elif inspect.isgenerator(result) or isinstance(result, Iterable):
+            asyncgen = iter_async(result)
+        else:
+            raise TypeError("Provided value cannot be iterated over.")
     else:
         raise TypeError("Provided value cannot be iterated over.")
     async for item in asyncgen:

--- a/hyperion/catalog/catalog.py
+++ b/hyperion/catalog/catalog.py
@@ -3,7 +3,6 @@
 import asyncio
 import dataclasses
 import datetime
-import io
 import re
 import shutil
 import tempfile
@@ -239,64 +238,38 @@ class Catalog:
 
     def _serialize_asset_to_tempfile(
         self, asset: AssetProtocol, data: Iterable[dict[str, Any]], schema_path: str | None = None
-    ) -> io.BytesIO | Path:
-        """Serialize ``data`` for ``asset`` and return either an in-memory buffer or a temp-file path.
+    ) -> tempfile.SpooledTemporaryFile[bytes]:
+        """Serialize ``data`` for ``asset`` into a spooled tempfile, seeked to 0.
 
-        Payloads up to ``spool_threshold_bytes`` are returned as an open
-        :class:`io.BytesIO` seeked to 0, so the caller can upload from RAM
-        without a disk round-trip. Larger payloads are spilled to a
-        ``NamedTemporaryFile(delete=False)`` and the :class:`~pathlib.Path` is
-        returned; the caller owns that path and must unlink it.
-
-        fastavro only requires ``seek`` / ``tell`` on the destination, which
-        BytesIO provides natively.
+        Payloads up to ``spool_threshold_bytes`` stay in memory; larger payloads
+        roll over to disk transparently *during* fastavro's write — the
+        serializer never has to fit the whole payload in RAM. The caller owns
+        the returned handle and must close it.
         """
         schema = (
             self.schema_store.get_asset_schema(asset)
             if schema_path is None
             else self.schema_store.get_schema_from_path(schema_path)
         )
-        buffer = io.BytesIO()
-        logger.info("Pouring asset into an in-memory buffer.", asset=asset)
-        self._serializer.write(buffer, schema, data, asset.to_metadata())
-        size = buffer.tell()
-        if size <= self.spool_threshold_bytes:
-            buffer.seek(0)
-            logger.info("Avro payload kept in memory.", asset=asset, size=size)
-            return buffer
-        file = tempfile.NamedTemporaryFile("+wb", delete=False)  # noqa: SIM115
-        path = Path(file.name)
+        spool: tempfile.SpooledTemporaryFile[bytes] = tempfile.SpooledTemporaryFile(  # noqa: SIM115
+            max_size=self.spool_threshold_bytes, mode="w+b"
+        )
         try:
-            logger.info(
-                "Avro payload exceeded spool threshold; spilling to disk.",
-                asset=asset,
-                size=size,
-                threshold=self.spool_threshold_bytes,
-                file=path.as_posix(),
-            )
-            buffer.seek(0)
-            shutil.copyfileobj(buffer, file)
+            logger.info("Serializing asset into spooled tempfile.", asset=asset)
+            self._serializer.write(spool, schema, data, asset.to_metadata())
         except BaseException:
-            file.close()
-            path.unlink(missing_ok=True)
+            spool.close()
             raise
-        finally:
-            buffer.close()
-        file.close()
-        return path
+        size = spool.tell()
+        spool.seek(0)
+        logger.info("Avro serialization complete.", asset=asset, size=size)
+        return spool
 
     @contextmanager
     def _prepare_asset_storage(
         self, asset: AssetProtocol, data: Iterable[dict[str, Any]], schema_path: str | None = None
     ) -> Iterator[IO[bytes]]:
         prepared = self._serialize_asset_to_tempfile(asset, data, schema_path)
-        if isinstance(prepared, Path):
-            try:
-                with prepared.open("rb") as file:
-                    yield file
-            finally:
-                prepared.unlink(missing_ok=True)
-            return
         try:
             yield prepared
         finally:
@@ -314,17 +287,10 @@ class Catalog:
         """
         logger.info("Preparing asset storage.", asset=asset)
         prepared = await asyncio.to_thread(self._serialize_asset_to_tempfile, asset, data, schema_path)
-        if isinstance(prepared, Path):
-            try:
-                with prepared.open("rb") as file:
-                    await self._resolve_storage(asset).put_async(asset.get_path(), file)
-            finally:
-                prepared.unlink(missing_ok=True)
-        else:
-            try:
-                await self._resolve_storage(asset).put_async(asset.get_path(), prepared)
-            finally:
-                prepared.close()
+        try:
+            await self._resolve_storage(asset).put_async(asset.get_path(), prepared)
+        finally:
+            prepared.close()
         if notify:
             self._notify_asset_arrival(asset, schema_path=schema_path)
 
@@ -644,11 +610,26 @@ class AssetRepartitioner(Generic[RepartitionableAsset]):
 
     def __exit__(self, *args: Any) -> None:
         try:
+            # Isolate per-partition cleanup failures so one bad writer / disk
+            # error doesn't leak the rest of the open handles or tempfiles.
             for partition_date in list(self._open_lru):
-                self._close_partition(partition_date, evict=False)
+                try:
+                    self._close_partition(partition_date, evict=False)
+                except Exception:
+                    logger.exception(
+                        "Failed to close partition writer during repartitioner exit.",
+                        partition_date=partition_date.isoformat(),
+                    )
             self._open_lru.clear()
-            for entry in self._partitions.values():
-                entry.path.unlink(missing_ok=True)
+            for partition_date, entry in self._partitions.items():
+                try:
+                    entry.path.unlink(missing_ok=True)
+                except Exception:
+                    logger.exception(
+                        "Failed to unlink partition tempfile during repartitioner exit.",
+                        partition_date=partition_date.isoformat(),
+                        path=entry.path.as_posix(),
+                    )
             self._partitions.clear()
         finally:
             self._entered = False
@@ -772,8 +753,17 @@ class AssetRepartitioner(Generic[RepartitionableAsset]):
 
     def _finalize_partitions(self) -> None:
         """Flush + close every still-open writer so the on-disk files are complete."""
+        # Isolate per-partition flush failures so one bad writer doesn't leave
+        # the rest open; __exit__ will still run, but partitions that did flush
+        # cleanly here are upload-ready as soon as we return.
         for partition_date in list(self._open_lru):
-            self._close_partition(partition_date, evict=False)
+            try:
+                self._close_partition(partition_date, evict=False)
+            except Exception:
+                logger.exception(
+                    "Failed to flush partition writer; remaining partitions still attempted.",
+                    partition_date=partition_date.isoformat(),
+                )
         self._open_lru.clear()
 
     async def repartition(self, data: Iterable[dict[str, Any]] | None = None) -> None:

--- a/hyperion/catalog/catalog.py
+++ b/hyperion/catalog/catalog.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import datetime
+import io
 import re
 import shutil
 import tempfile
@@ -166,6 +167,7 @@ class Catalog:
     """
 
     _ASSET_TYPES: ClassVar[tuple[AssetType, ...]] = ("data_lake", "feature", "persistent_store")
+    DEFAULT_SPOOL_THRESHOLD_BYTES: ClassVar[int] = 8 * 1024 * 1024
 
     def __init__(
         self,
@@ -175,6 +177,7 @@ class Catalog:
         cache: "Cache | None" = None,
         schema_store: "SchemaStore | None" = None,
         serializer: AvroSerializer | None = None,
+        spool_threshold_bytes: int = DEFAULT_SPOOL_THRESHOLD_BYTES,
     ) -> None:
         """Initialize the catalog.
 
@@ -188,6 +191,10 @@ class Catalog:
             cache (Cache, optional): The cache to use for storing assets for quicker re-retrieval. Defaults to None.
             schema_store (SchemaStore, optional): The schema store. Defaults to ``SchemaStore.from_config()``.
             serializer (AvroSerializer, optional): The avro serializer. Defaults to a fresh ``AvroSerializer``.
+            spool_threshold_bytes (int, optional): Upper bound (inclusive) for in-memory
+                avro serialization on the store-asset path. Payloads at or below this size
+                upload from a BytesIO buffer; larger payloads are promoted to an on-disk
+                temp file. Defaults to 8 MiB.
         """
         if isinstance(storage, Mapping):
             missing = [asset_type for asset_type in self._ASSET_TYPES if asset_type not in storage]
@@ -206,6 +213,7 @@ class Catalog:
             )
 
         self.schema_store = schema_store or SchemaStore.from_config()
+        self.spool_threshold_bytes = spool_threshold_bytes
 
     def _resolve_storage(self, asset: AssetProtocol | type[AssetProtocol]) -> StoragePort:
         try:
@@ -229,26 +237,49 @@ class Catalog:
 
     def _serialize_asset_to_tempfile(
         self, asset: AssetProtocol, data: Iterable[dict[str, Any]], schema_path: str | None = None
-    ) -> Path:
-        """Serialize ``data`` for ``asset`` into a closed temp file and return its path.
+    ) -> io.BytesIO | Path:
+        """Serialize ``data`` for ``asset`` and return either an in-memory buffer or a temp-file path.
 
-        The caller owns the returned path and is responsible for deleting it.
+        Payloads up to ``spool_threshold_bytes`` are returned as an open
+        :class:`io.BytesIO` seeked to 0, so the caller can upload from RAM
+        without a disk round-trip. Larger payloads are spilled to a
+        ``NamedTemporaryFile(delete=False)`` and the :class:`~pathlib.Path` is
+        returned; the caller owns that path and must unlink it.
+
+        fastavro only requires ``seek`` / ``tell`` on the destination, which
+        BytesIO provides natively.
         """
         schema = (
             self.schema_store.get_asset_schema(asset)
             if schema_path is None
             else self.schema_store.get_schema_from_path(schema_path)
         )
+        buffer = io.BytesIO()
+        logger.info("Pouring asset into an in-memory buffer.", asset=asset)
+        self._serializer.write(buffer, schema, data, asset.to_metadata())
+        size = buffer.tell()
+        if size <= self.spool_threshold_bytes:
+            buffer.seek(0)
+            logger.info("Avro payload kept in memory.", asset=asset, size=size)
+            return buffer
         file = tempfile.NamedTemporaryFile("+wb", delete=False)  # noqa: SIM115
         path = Path(file.name)
         try:
-            logger.info("Pouring asset into a temporary file.", asset=asset, file=path.as_posix())
-            self._serializer.write(file, schema, data, asset.to_metadata())
-            logger.info("Avro file was created successfully.", path=path.as_posix(), size=file.tell())
+            logger.info(
+                "Avro payload exceeded spool threshold; spilling to disk.",
+                asset=asset,
+                size=size,
+                threshold=self.spool_threshold_bytes,
+                file=path.as_posix(),
+            )
+            buffer.seek(0)
+            shutil.copyfileobj(buffer, file)
         except BaseException:
             file.close()
             path.unlink(missing_ok=True)
             raise
+        finally:
+            buffer.close()
         file.close()
         return path
 
@@ -256,12 +287,18 @@ class Catalog:
     def _prepare_asset_storage(
         self, asset: AssetProtocol, data: Iterable[dict[str, Any]], schema_path: str | None = None
     ) -> Iterator[IO[bytes]]:
-        path = self._serialize_asset_to_tempfile(asset, data, schema_path)
+        prepared = self._serialize_asset_to_tempfile(asset, data, schema_path)
+        if isinstance(prepared, Path):
+            try:
+                with prepared.open("rb") as file:
+                    yield file
+            finally:
+                prepared.unlink(missing_ok=True)
+            return
         try:
-            with path.open("rb") as file:
-                yield file
+            yield prepared
         finally:
-            path.unlink(missing_ok=True)
+            prepared.close()
 
     async def store_asset_async(
         self, asset: AssetProtocol, data: Iterable[dict[str, Any]], notify: bool = True, schema_path: str | None = None
@@ -274,12 +311,18 @@ class Catalog:
             notify (bool, optional): Whether to send a notification. Defaults to True.
         """
         logger.info("Preparing asset storage.", asset=asset)
-        prepared_path = await asyncio.to_thread(self._serialize_asset_to_tempfile, asset, data, schema_path)
-        try:
-            with prepared_path.open("rb") as file:
-                await self._resolve_storage(asset).put_async(asset.get_path(), file)
-        finally:
-            prepared_path.unlink(missing_ok=True)
+        prepared = await asyncio.to_thread(self._serialize_asset_to_tempfile, asset, data, schema_path)
+        if isinstance(prepared, Path):
+            try:
+                with prepared.open("rb") as file:
+                    await self._resolve_storage(asset).put_async(asset.get_path(), file)
+            finally:
+                prepared.unlink(missing_ok=True)
+        else:
+            try:
+                await self._resolve_storage(asset).put_async(asset.get_path(), prepared)
+            finally:
+                prepared.close()
         if notify:
             self._notify_asset_arrival(asset, schema_path=schema_path)
 

--- a/hyperion/catalog/catalog.py
+++ b/hyperion/catalog/catalog.py
@@ -1,11 +1,13 @@
 """The data catalog."""
 
 import asyncio
+import dataclasses
 import datetime
 import io
 import re
 import shutil
 import tempfile
+from collections import OrderedDict
 from collections.abc import Iterable, Iterator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
@@ -577,8 +579,25 @@ class Catalog:
         await repartitioner.repartition(data)
 
 
+@dataclasses.dataclass
+class _PartitionEntry(Generic[RepartitionableAsset]):
+    """Per-partition state used by :class:`AssetRepartitioner`.
+
+    ``path`` is created once via ``NamedTemporaryFile(delete=False)`` and lives for the
+    full repartition. ``open_handle`` is populated only while the partition is in the
+    bounded LRU of currently-open writers; eviction sets it back to ``None`` and a
+    later write reopens the same path in ``a+b`` so fastavro resumes the container.
+    """
+
+    asset: RepartitionableAsset
+    path: Path
+    open_handle: tuple[IO[bytes], AvroStreamWriter] | None = None
+
+
 class AssetRepartitioner(Generic[RepartitionableAsset]):
     """A class to repartition a data lake asset based on a time resolution unit."""
+
+    DEFAULT_MAX_OPEN_WRITERS: ClassVar[int] = 256
 
     def __init__(
         self,
@@ -586,6 +605,7 @@ class AssetRepartitioner(Generic[RepartitionableAsset]):
         asset: RepartitionableAsset,
         granularity: TimeResolutionUnit,
         date_attribute: str = "timestamp",
+        max_open_writers: int = DEFAULT_MAX_OPEN_WRITERS,
     ) -> None:
         """Initialize the repartitioner.
 
@@ -594,22 +614,44 @@ class AssetRepartitioner(Generic[RepartitionableAsset]):
             asset (DataLakeAsset | FeatureAsset): The asset to repartition.
             granularity (TimeResolutionUnit): The time resolution unit to use.
             date_attribute (str, optional): The date attribute to use. Defaults to "timestamp".
+            max_open_writers (int, optional): Maximum number of avro stream writers (and
+                therefore tempfile descriptors) kept open concurrently. Defaults to 256.
+                When more partitions are touched than this, the least-recently-used
+                writer is flushed + closed; a later write to that partition reopens
+                its file in ``a+b`` so fastavro resumes the same container.
         """
+        if max_open_writers < 1:
+            raise ValueError(f"max_open_writers must be >= 1, got {max_open_writers!r}.")
+
         self.catalog = catalog
         self.asset = asset
         self.granularity = granularity
         self.date_attribute = date_attribute
+        self.max_open_writers = max_open_writers
         self._partition_name = "date" if isinstance(self.asset, DataLakeAsset) else "timestamp"
 
-        self._state: dict[datetime.datetime, tuple[IO[bytes], RepartitionableAsset, AvroStreamWriter]] = {}
+        self._partitions: dict[datetime.datetime, _PartitionEntry[RepartitionableAsset]] = {}
+        # LRU of partitions with a live (file, writer); the *value* is unused, the
+        # OrderedDict is only consulted for ordering + membership.
+        self._open_lru: OrderedDict[datetime.datetime, None] = OrderedDict()
+        self._entered = False
 
-    def __enter__(self) -> None:
-        self._state = {}
+    def __enter__(self) -> "AssetRepartitioner[RepartitionableAsset]":
+        if self._entered:
+            raise RuntimeError("AssetRepartitioner context is not reentrant")
+        self._entered = True
+        return self
 
     def __exit__(self, *args: Any) -> None:
-        for file, _, __ in self._state.values():
-            logger.info("Closing temporary file.", path=file.name)
-            file.close()
+        try:
+            for partition_date in list(self._open_lru):
+                self._close_partition(partition_date, evict=False)
+            self._open_lru.clear()
+            for entry in self._partitions.values():
+                entry.path.unlink(missing_ok=True)
+            self._partitions.clear()
+        finally:
+            self._entered = False
 
     def _create_partition_asset(self, partition_date: datetime.datetime) -> RepartitionableAsset:
         if isinstance(self.asset, DataLakeAsset):
@@ -627,21 +669,93 @@ class AssetRepartitioner(Generic[RepartitionableAsset]):
             )
         raise TypeError(f"Unsupported asset type {type(self.asset)!r}.")
 
-    def _get_handler(
-        self, partition_date: datetime.datetime
-    ) -> tuple[IO[bytes], RepartitionableAsset, AvroStreamWriter]:
-        if partition_date in self._state:
-            return self._state[partition_date]
-        logger.info("Creating a new handler for partition date.", partition_date=partition_date.isoformat())
-        file = tempfile.NamedTemporaryFile("+wb")  # noqa: SIM115
-        logger.info(f"Partition will be temporarily stored in {file.name!r}.", path=file.name)
-        asset = self._create_partition_asset(partition_date)
-        writer = self.catalog._serializer.streaming_writer(
-            file, self.catalog.schema_store.get_asset_schema(asset), asset.to_metadata()
-        )
-        handler = (file, asset, writer)
-        self._state[partition_date] = handler
-        return handler
+    def _close_partition(self, partition_date: datetime.datetime, *, evict: bool) -> None:
+        """Flush + close the open writer for ``partition_date``.
+
+        With ``evict=True`` the file's bytes are kept on disk so a later write can
+        reopen it; with ``evict=False`` we additionally drop the dict slot.
+        """
+        entry = self._partitions[partition_date]
+        if entry.open_handle is None:
+            return
+        file, writer = entry.open_handle
+        try:
+            writer.dump()
+        finally:
+            file.close()
+            entry.open_handle = None
+        if evict:
+            logger.info(
+                "Evicting open avro writer to stay within max_open_writers.",
+                partition_date=partition_date.isoformat(),
+                path=entry.path.as_posix(),
+            )
+
+    def _open_writer(
+        self, entry: _PartitionEntry[RepartitionableAsset], *, reopen: bool
+    ) -> tuple[IO[bytes], AvroStreamWriter]:
+        """Open (or reopen) the avro stream writer for ``entry``.
+
+        On reopen, fastavro detects a non-empty appendable file (``a+b``), re-reads the
+        container header/sync marker, and continues writing new blocks after the
+        existing ones — no header duplication.
+        """
+        mode = "a+b" if reopen else "w+b"
+        file = entry.path.open(mode)
+        try:
+            writer = self.catalog._serializer.streaming_writer(
+                file,
+                self.catalog.schema_store.get_asset_schema(entry.asset),
+                entry.asset.to_metadata(),
+            )
+        except BaseException:
+            file.close()
+            raise
+        return file, writer
+
+    def _evict_lru_if_needed(self) -> None:
+        while len(self._open_lru) >= self.max_open_writers:
+            lru_date, _ = self._open_lru.popitem(last=False)
+            self._close_partition(lru_date, evict=True)
+
+    def _get_writer(self, partition_date: datetime.datetime) -> AvroStreamWriter:
+        entry = self._partitions.get(partition_date)
+        if entry is not None and entry.open_handle is not None:
+            self._open_lru.move_to_end(partition_date)
+            return entry.open_handle[1]
+
+        self._evict_lru_if_needed()
+
+        if entry is None:
+            asset = self._create_partition_asset(partition_date)
+            # If anything between the tempfile creation and the dict insert raises
+            # (including KeyboardInterrupt/SystemExit), close the handle and unlink
+            # the path so we don't leak fds or files.
+            tmp = tempfile.NamedTemporaryFile("w+b", delete=False)  # noqa: SIM115
+            tmp_file: IO[bytes] = cast(IO[bytes], tmp)
+            path = Path(tmp.name)
+            try:
+                writer = self.catalog._serializer.streaming_writer(
+                    tmp_file, self.catalog.schema_store.get_asset_schema(asset), asset.to_metadata()
+                )
+                entry = _PartitionEntry(asset=asset, path=path, open_handle=(tmp_file, writer))
+                self._partitions[partition_date] = entry
+                self._open_lru[partition_date] = None
+            except BaseException:
+                tmp_file.close()
+                path.unlink(missing_ok=True)
+                raise
+            logger.info(
+                "Created partition tempfile.",
+                partition_date=partition_date.isoformat(),
+                path=path.as_posix(),
+            )
+            return writer
+
+        reopened_file, reopened_writer = self._open_writer(entry, reopen=True)
+        entry.open_handle = (reopened_file, reopened_writer)
+        self._open_lru[partition_date] = None
+        return reopened_writer
 
     def _write_records(self, data: Iterable[dict[str, Any]]) -> None:
         """Drain ``data`` into per-partition streaming writers (blocking)."""
@@ -653,8 +767,14 @@ class AssetRepartitioner(Generic[RepartitionableAsset]):
                     f"{self.date_attribute!r} - it is not a valid datetime."
                 )
             partition_date = truncate_datetime(timestamp, self.granularity)
-            _, __, writer = self._get_handler(partition_date)
+            writer = self._get_writer(partition_date)
             writer.write(record)
+
+    def _finalize_partitions(self) -> None:
+        """Flush + close every still-open writer so the on-disk files are complete."""
+        for partition_date in list(self._open_lru):
+            self._close_partition(partition_date, evict=False)
+        self._open_lru.clear()
 
     async def repartition(self, data: Iterable[dict[str, Any]] | None = None) -> None:
         """Repartition the asset.
@@ -669,11 +789,24 @@ class AssetRepartitioner(Generic[RepartitionableAsset]):
         data = data or self.catalog.retrieve_asset(self.asset)
         with self:
             await asyncio.to_thread(self._write_records, data)
+            await asyncio.to_thread(self._finalize_partitions)
             logger.info("Finished creating partitioned avro files.")
 
             async with AsyncTaskQueue[None](maxsize=5) as queue:
-                async for file, asset, writer in aiter_any(self._state.values()):
-                    logger.info("Dumping and uploading asset from temporary file.", asset=asset, path=file.name)
-                    await asyncio.to_thread(writer.dump)
-                    file.seek(0)
-                    await queue.add_task(self.catalog._resolve_storage(asset).put_async(asset.get_path(), file))
+                async for partition_date, entry in aiter_any(self._partitions.items()):
+                    logger.info(
+                        "Uploading partitioned avro file.",
+                        asset=entry.asset,
+                        path=entry.path.as_posix(),
+                        partition_date=partition_date.isoformat(),
+                    )
+                    upload_file = entry.path.open("rb")
+                    await queue.add_task(
+                        self._upload_and_close(entry.asset, upload_file),
+                    )
+
+    async def _upload_and_close(self, asset: RepartitionableAsset, file: IO[bytes]) -> None:
+        try:
+            await self.catalog._resolve_storage(asset).put_async(asset.get_path(), file)
+        finally:
+            file.close()

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -2,6 +2,7 @@ import datetime
 import io
 import json
 import re
+import tempfile
 import types
 from pathlib import Path
 from typing import Any
@@ -887,13 +888,12 @@ def test_serialize_spool_small_payload_stays_in_memory(tmp_path: Path) -> None:
     asset = DataLakeAsset("spoolasset", utcnow())
     prepared = catalog._serialize_asset_to_tempfile(asset, [{"id": "tiny"}])
     try:
-        assert isinstance(prepared, io.BytesIO)
-        assert not isinstance(prepared, Path)
+        assert isinstance(prepared, tempfile.SpooledTemporaryFile)
+        assert prepared._rolled is False, "small payload should not roll to disk"  # type: ignore[attr-defined]
         assert prepared.tell() == 0, "buffer should be seeked to 0 ready for upload"
         assert prepared.read(4) != b""
     finally:
-        if isinstance(prepared, io.BytesIO):
-            prepared.close()
+        prepared.close()
 
 
 def test_serialize_spool_large_payload_promotes_to_disk(tmp_path: Path) -> None:
@@ -909,12 +909,14 @@ def test_serialize_spool_large_payload_promotes_to_disk(tmp_path: Path) -> None:
     # even after deflate.
     records = [{"id": f"row-{i:08d}-{uuid4().hex}"} for i in range(200)]
     prepared = catalog._serialize_asset_to_tempfile(asset, records)
-    assert isinstance(prepared, Path)
     try:
-        assert prepared.is_file()
-        assert prepared.stat().st_size > 512
+        assert isinstance(prepared, tempfile.SpooledTemporaryFile)
+        assert prepared._rolled is True, "payload over threshold should roll to disk"  # type: ignore[attr-defined]
+        prepared.seek(0, 2)
+        assert prepared.tell() > 512
+        prepared.seek(0)
     finally:
-        prepared.unlink(missing_ok=True)
+        prepared.close()
 
 
 async def test_serialize_spool_round_trip_small(tmp_path: Path) -> None:
@@ -1155,3 +1157,62 @@ class TestAssetRepartitionerHardening:
         b_rows = {row["id"] for row in catalog.retrieve_asset(partitions[1])}
         assert a_rows == {"a1", "a2", "a3", "a4"}
         assert b_rows == {"b1", "b2"}
+
+    def test_repartitioner_exit_continues_after_close_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A mid-loop close failure must not abandon the rest of the open writers."""
+        import tempfile as _tempfile
+
+        from hyperion.catalog.catalog import AssetRepartitioner
+
+        schema_dir = tmp_path / "schemas" / "data_lake"
+        schema_dir.mkdir(parents=True)
+        (schema_dir / "repart_exit.v1.avro.json").write_text(json.dumps(_TS_SCHEMA))
+
+        catalog = Catalog(
+            storage=MemoryStorage(),
+            schema_store=LocalSchemaStore(tmp_path / "schemas"),
+            queue=InMemoryQueue(),
+        )
+        day_one = datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC)
+        source_asset = DataLakeAsset("repart_exit", day_one)
+
+        repartitioner = AssetRepartitioner(catalog, source_asset, "d", "timestamp")
+        partition_a = datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC)
+        partition_b = datetime.datetime(2025, 1, 2, tzinfo=datetime.UTC)
+
+        # Patch dump() on the first writer encountered to raise; the second
+        # partition's writer must still be closed and its tempfile unlinked.
+        original_dump = AvroStreamWriter.dump
+        sabotaged: dict[str, bool] = {"done": False}
+
+        def maybe_exploding_dump(self: AvroStreamWriter) -> None:
+            if not sabotaged["done"]:
+                sabotaged["done"] = True
+                raise OSError("simulated disk failure during dump()")
+            original_dump(self)
+
+        monkeypatch.setattr(AvroStreamWriter, "dump", maybe_exploding_dump)
+
+        tmp_root = Path(_tempfile.gettempdir())
+        before = set(tmp_root.iterdir())
+
+        with repartitioner:
+            writer_a = repartitioner._get_writer(partition_a)
+            writer_a.write({"id": "a1", "timestamp": partition_a})
+            writer_b = repartitioner._get_writer(partition_b)
+            writer_b.write({"id": "b1", "timestamp": partition_b})
+            # _finalize_partitions would close both; but __exit__ also closes
+            # whatever is still open. Skip the finalize call so __exit__ owns
+            # both partitions and exercises the per-partition exception guard.
+            paths_in_play = [entry.path for entry in repartitioner._partitions.values()]
+
+        # __exit__ must have cleared all state and unlinked every tempfile,
+        # even though one writer.dump() raised mid-loop.
+        assert repartitioner._partitions == {}
+        assert not repartitioner._open_lru
+        leaked = set(tmp_root.iterdir()) - before
+        assert leaked == set(), f"__exit__ leaked tempfile(s) after mid-loop failure: {leaked!r}"
+        for path in paths_in_play:
+            assert not path.exists(), f"partition tempfile {path} survived __exit__"

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -965,3 +965,193 @@ async def test_serialize_spool_round_trip_large(tmp_path: Path) -> None:
     catalog.store_asset(sync_asset, records, notify=False)
     assert set(tmp_root.iterdir()) - before == set()
     assert list(catalog.retrieve_asset(sync_asset)) == records
+
+
+class _OpenFdTracker:
+    """Counts currently-open tempfile fds that look like avro repartition tempfiles."""
+
+    @staticmethod
+    def count_open_repartition_tempfiles() -> int:
+        import tempfile as _tempfile
+
+        fd_root = Path("/proc/self/fd")
+        if not fd_root.exists():  # pragma: no cover - non-Linux
+            return -1
+        tempdir = _tempfile.gettempdir()
+        count = 0
+        for entry in fd_root.iterdir():
+            try:
+                target = entry.resolve(strict=False).as_posix()
+            except OSError:  # pragma: no cover - racing fd close
+                continue
+            if target.startswith(tempdir) and "tmp" in Path(target).name:
+                count += 1
+        return count
+
+
+class _FdRecordingStreamWriter:
+    """Wraps a real fastavro stream writer; records a max-open-fd watermark per write."""
+
+    def __init__(self, inner: AvroStreamWriter, owner: "_FdRecordingSerializer") -> None:
+        self._inner = inner
+        self._owner = owner
+
+    def write(self, record: dict[str, Any]) -> None:
+        current = _OpenFdTracker.count_open_repartition_tempfiles()
+        if current > self._owner.max_observed_open_fds:
+            self._owner.max_observed_open_fds = current
+        self._inner.write(record)
+
+    def dump(self) -> None:
+        self._inner.dump()
+
+
+class _FdRecordingSerializer(AvroSerializer):
+    """Watches how many repartition tempfiles are open during each per-record write."""
+
+    def __init__(self) -> None:
+        self.max_observed_open_fds = 0
+
+    def streaming_writer(self, fp: Any, schema: dict[str, Any], metadata: dict[str, str]) -> AvroStreamWriter:
+        return _FdRecordingStreamWriter(super().streaming_writer(fp, schema, metadata), self)
+
+
+class TestAssetRepartitionerHardening:
+    async def test_repartitioner_lru_evicts_when_over_max_open_writers(self, tmp_path: Path) -> None:
+        from hyperion.catalog.catalog import AssetRepartitioner
+
+        schema_dir = tmp_path / "schemas" / "data_lake"
+        schema_dir.mkdir(parents=True)
+        (schema_dir / "repart_lru.v1.avro.json").write_text(json.dumps(_TS_SCHEMA))
+
+        serializer = _FdRecordingSerializer()
+        catalog = Catalog(
+            storage=MemoryStorage(),
+            schema_store=LocalSchemaStore(tmp_path / "schemas"),
+            queue=InMemoryQueue(),
+            serializer=serializer,
+        )
+        day_one = datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC)
+        records = [
+            {"id": "p1-a", "timestamp": datetime.datetime(2025, 1, 1, 8, tzinfo=datetime.UTC)},
+            {"id": "p2-a", "timestamp": datetime.datetime(2025, 1, 2, 8, tzinfo=datetime.UTC)},
+            {"id": "p3-a", "timestamp": datetime.datetime(2025, 1, 3, 8, tzinfo=datetime.UTC)},
+            {"id": "p1-b", "timestamp": datetime.datetime(2025, 1, 1, 9, tzinfo=datetime.UTC)},
+            {"id": "p2-b", "timestamp": datetime.datetime(2025, 1, 2, 9, tzinfo=datetime.UTC)},
+            {"id": "p3-b", "timestamp": datetime.datetime(2025, 1, 3, 9, tzinfo=datetime.UTC)},
+        ]
+        source_asset = DataLakeAsset("repart_lru", day_one)
+
+        repartitioner = AssetRepartitioner(catalog, source_asset, "d", "timestamp", max_open_writers=2)
+        await repartitioner.repartition(records)
+
+        assert serializer.max_observed_open_fds <= 2, (
+            f"LRU bound violated: observed {serializer.max_observed_open_fds} open tempfiles"
+        )
+        partitions = sorted(catalog.iter_datalake_partitions("repart_lru"), key=lambda asset: asset.date)
+        assert len(partitions) == 3
+        ids_per_partition = [{row["id"] for row in catalog.retrieve_asset(p)} for p in partitions]
+        assert ids_per_partition == [{"p1-a", "p1-b"}, {"p2-a", "p2-b"}, {"p3-a", "p3-b"}]
+
+    def test_repartitioner_reentry_raises(self, tmp_path: Path) -> None:
+        from hyperion.catalog.catalog import AssetRepartitioner
+
+        schema_dir = tmp_path / "schemas" / "data_lake"
+        schema_dir.mkdir(parents=True)
+        (schema_dir / "repart_reentry.v1.avro.json").write_text(json.dumps(_TS_SCHEMA))
+
+        catalog = Catalog(
+            storage=MemoryStorage(),
+            schema_store=LocalSchemaStore(tmp_path / "schemas"),
+            queue=InMemoryQueue(),
+        )
+        asset = DataLakeAsset("repart_reentry", datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC))
+        repartitioner = AssetRepartitioner(catalog, asset, "d", "timestamp")
+
+        with repartitioner, pytest.raises(RuntimeError, match="not reentrant"):
+            repartitioner.__enter__()
+
+        # Once the context exits cleanly, a fresh `with` is allowed.
+        with repartitioner:
+            pass
+
+    def test_repartitioner_baseexception_cleanup_in_get_handler(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import tempfile as _tempfile
+
+        from hyperion.catalog.catalog import AssetRepartitioner
+
+        schema_dir = tmp_path / "schemas" / "data_lake"
+        schema_dir.mkdir(parents=True)
+        (schema_dir / "repart_be.v1.avro.json").write_text(json.dumps(_TS_SCHEMA))
+
+        catalog = Catalog(
+            storage=MemoryStorage(),
+            schema_store=LocalSchemaStore(tmp_path / "schemas"),
+            queue=InMemoryQueue(),
+        )
+        source_asset = DataLakeAsset("repart_be", datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC))
+        repartitioner = AssetRepartitioner(catalog, source_asset, "d", "timestamp")
+
+        tmp_root = Path(_tempfile.gettempdir())
+        tempfiles_before = set(tmp_root.iterdir())
+
+        boom_calls = {"n": 0}
+        real_streaming_writer = catalog._serializer.streaming_writer
+
+        def exploding_streaming_writer(*args: Any, **kwargs: Any) -> Any:
+            boom_calls["n"] += 1
+            raise KeyboardInterrupt("simulated SIGINT after NamedTemporaryFile() and before insert")
+
+        monkeypatch.setattr(catalog._serializer, "streaming_writer", exploding_streaming_writer)
+
+        with repartitioner:
+            with pytest.raises(KeyboardInterrupt):
+                repartitioner._get_writer(datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC))
+            # Reinstate the real writer so __exit__ doesn't double-fault on already-clean state.
+            monkeypatch.setattr(catalog._serializer, "streaming_writer", real_streaming_writer)
+
+        assert boom_calls["n"] == 1
+        # No partition state was inserted, nothing to leak.
+        assert repartitioner._partitions == {}
+        assert not repartitioner._open_lru
+        leaked = set(tmp_root.iterdir()) - tempfiles_before
+        assert leaked == set(), f"BaseException path leaked tempfile(s): {leaked!r}"
+
+    async def test_repartitioner_round_trip_after_eviction(self, tmp_path: Path) -> None:
+        from hyperion.catalog.catalog import AssetRepartitioner
+
+        schema_dir = tmp_path / "schemas" / "data_lake"
+        schema_dir.mkdir(parents=True)
+        (schema_dir / "repart_rt.v1.avro.json").write_text(json.dumps(_TS_SCHEMA))
+
+        catalog = Catalog(
+            storage=MemoryStorage(),
+            schema_store=LocalSchemaStore(tmp_path / "schemas"),
+            queue=InMemoryQueue(),
+        )
+        day_one = datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC)
+        records = [
+            {"id": "a1", "timestamp": datetime.datetime(2025, 1, 1, 1, tzinfo=datetime.UTC)},
+            {"id": "a2", "timestamp": datetime.datetime(2025, 1, 1, 2, tzinfo=datetime.UTC)},
+            {"id": "b1", "timestamp": datetime.datetime(2025, 1, 2, 1, tzinfo=datetime.UTC)},
+            # The next write to partition A must reopen its file after eviction by B.
+            {"id": "a3", "timestamp": datetime.datetime(2025, 1, 1, 3, tzinfo=datetime.UTC)},
+            {"id": "b2", "timestamp": datetime.datetime(2025, 1, 2, 2, tzinfo=datetime.UTC)},
+            {"id": "a4", "timestamp": datetime.datetime(2025, 1, 1, 4, tzinfo=datetime.UTC)},
+        ]
+        source_asset = DataLakeAsset("repart_rt", day_one)
+
+        repartitioner = AssetRepartitioner(catalog, source_asset, "d", "timestamp", max_open_writers=1)
+        await repartitioner.repartition(records)
+
+        partitions = sorted(catalog.iter_datalake_partitions("repart_rt"), key=lambda asset: asset.date)
+        assert [p.date for p in partitions] == [
+            datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC),
+            datetime.datetime(2025, 1, 2, tzinfo=datetime.UTC),
+        ]
+        a_rows = {row["id"] for row in catalog.retrieve_asset(partitions[0])}
+        b_rows = {row["id"] for row in catalog.retrieve_asset(partitions[1])}
+        assert a_rows == {"a1", "a2", "a3", "a4"}
+        assert b_rows == {"b1", "b2"}

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -860,3 +860,108 @@ class TestRepartitionDoesNotBlockLoop:
         ]
         assert {row["id"] for row in catalog.retrieve_asset(partitions[0])} == {"a", "b"}
         assert {row["id"] for row in catalog.retrieve_asset(partitions[1])} == {"c"}
+
+
+# -----------------------------------------------------------------------------
+# Spool-to-disk threshold (issue #201). Small payloads must round-trip through a
+# BytesIO buffer instead of NamedTemporaryFile; only oversized payloads spill to
+# disk.
+# -----------------------------------------------------------------------------
+
+
+def _spool_schema_dir(tmp_path: Path) -> Path:
+    schema_dir = tmp_path / "schemas" / "data_lake"
+    schema_dir.mkdir(parents=True)
+    schema = {"type": "record", "name": "Spool", "fields": [{"name": "id", "type": "string"}]}
+    (schema_dir / "spoolasset.v1.avro.json").write_text(json.dumps(schema))
+    return tmp_path / "schemas"
+
+
+def test_serialize_spool_small_payload_stays_in_memory(tmp_path: Path) -> None:
+    schemas_root = _spool_schema_dir(tmp_path)
+    catalog = Catalog(
+        storage=MemoryStorage(),
+        schema_store=LocalSchemaStore(schemas_root),
+        queue=InMemoryQueue(),
+    )
+    asset = DataLakeAsset("spoolasset", utcnow())
+    prepared = catalog._serialize_asset_to_tempfile(asset, [{"id": "tiny"}])
+    try:
+        assert isinstance(prepared, io.BytesIO)
+        assert not isinstance(prepared, Path)
+        assert prepared.tell() == 0, "buffer should be seeked to 0 ready for upload"
+        assert prepared.read(4) != b""
+    finally:
+        if isinstance(prepared, io.BytesIO):
+            prepared.close()
+
+
+def test_serialize_spool_large_payload_promotes_to_disk(tmp_path: Path) -> None:
+    schemas_root = _spool_schema_dir(tmp_path)
+    catalog = Catalog(
+        storage=MemoryStorage(),
+        schema_store=LocalSchemaStore(schemas_root),
+        queue=InMemoryQueue(),
+        spool_threshold_bytes=512,
+    )
+    asset = DataLakeAsset("spoolasset", utcnow())
+    # Many records of incompressible (random-looking) ids easily clear 512 bytes
+    # even after deflate.
+    records = [{"id": f"row-{i:08d}-{uuid4().hex}"} for i in range(200)]
+    prepared = catalog._serialize_asset_to_tempfile(asset, records)
+    assert isinstance(prepared, Path)
+    try:
+        assert prepared.is_file()
+        assert prepared.stat().st_size > 512
+    finally:
+        prepared.unlink(missing_ok=True)
+
+
+async def test_serialize_spool_round_trip_small(tmp_path: Path) -> None:
+    import tempfile as _tempfile
+
+    schemas_root = _spool_schema_dir(tmp_path)
+    catalog = Catalog(
+        storage=MemoryStorage(),
+        schema_store=LocalSchemaStore(schemas_root),
+        queue=InMemoryQueue(),
+    )
+    asset = DataLakeAsset("spoolasset", utcnow())
+    records = [{"id": "alpha"}, {"id": "beta"}]
+    tmp_root = Path(_tempfile.gettempdir())
+    before = set(tmp_root.iterdir())
+    await catalog.store_asset_async(asset, records, notify=False)
+    # In-memory path should leave no temp-file droppings.
+    assert set(tmp_root.iterdir()) - before == set()
+    assert list(catalog.retrieve_asset(asset)) == records
+    # Sync path goes through the same in-memory branch via _prepare_asset_storage.
+    sync_asset = DataLakeAsset("spoolasset", utcnow() + datetime.timedelta(seconds=1))
+    before = set(tmp_root.iterdir())
+    catalog.store_asset(sync_asset, records, notify=False)
+    assert set(tmp_root.iterdir()) - before == set()
+    assert list(catalog.retrieve_asset(sync_asset)) == records
+
+
+async def test_serialize_spool_round_trip_large(tmp_path: Path) -> None:
+    import tempfile as _tempfile
+
+    schemas_root = _spool_schema_dir(tmp_path)
+    catalog = Catalog(
+        storage=MemoryStorage(),
+        schema_store=LocalSchemaStore(schemas_root),
+        queue=InMemoryQueue(),
+        spool_threshold_bytes=512,
+    )
+    asset = DataLakeAsset("spoolasset", utcnow())
+    records = [{"id": f"row-{i:08d}-{uuid4().hex}"} for i in range(200)]
+    tmp_root = Path(_tempfile.gettempdir())
+    before = set(tmp_root.iterdir())
+    await catalog.store_asset_async(asset, records, notify=False)
+    # On-disk path cleans up its own temp file after upload.
+    assert set(tmp_root.iterdir()) - before == set()
+    assert list(catalog.retrieve_asset(asset)) == records
+    sync_asset = DataLakeAsset("spoolasset", utcnow() + datetime.timedelta(seconds=1))
+    before = set(tmp_root.iterdir())
+    catalog.store_asset(sync_asset, records, notify=False)
+    assert set(tmp_root.iterdir()) - before == set()
+    assert list(catalog.retrieve_asset(sync_asset)) == records

--- a/tests/test_asyncutils.py
+++ b/tests/test_asyncutils.py
@@ -70,6 +70,29 @@ async def test_aiter_unsupported() -> None:
         await collect_test(None)
 
 
+async def test_aiter_callable_sync() -> None:
+    assert await collect_test(lambda: [0, 1, 2, 3, 4]) == {0, 1, 2, 3, 4}
+
+
+async def test_aiter_callable_def_sync() -> None:
+    def factory() -> list[int]:
+        return [0, 1, 2, 3, 4]
+
+    assert await collect_test(factory) == {0, 1, 2, 3, 4}
+
+
+async def test_aiter_callable_async() -> None:
+    def factory() -> AsyncList:
+        return AsyncList([0, 1, 2, 3, 4])
+
+    assert await collect_test(factory) == {0, 1, 2, 3, 4}
+
+
+async def test_aiter_callable_returning_noniterable() -> None:
+    with pytest.raises(TypeError, match=r"Provided value cannot be iterated over."):
+        await collect_test(lambda: (lambda: [1, 2, 3]))
+
+
 @pytest.mark.parametrize(("maxsize", "max_duration", "min_duration"), [(0, 2, 1), (2, 4, 2)])
 async def test_async_task_queue(maxsize: int, max_duration: int, min_duration: int) -> None:
     class _Cororun:


### PR DESCRIPTION
First wave of the v2.0 async overhaul (epic #193). Three independent, non-breaking issues bundled into one PR via per-issue worktrees. Targets the long-lived `v2.0` branch; master stays on the 1.x patch track.

## Summary

- **#203** `fix(asyncutils): handle plain callables in aiter_any` — the signature advertised `Callable[[], Iterable[T] | AsyncIterable[T]]` but the body only handled `isasyncgenfunction` / `isgeneratorfunction`, so a plain `lambda: [1, 2, 3]` raised `TypeError`. One-hop callable branch added.
- **#202** `fix(catalog): bounded writer LRU + reentrancy guard in AssetRepartitioner` — `_get_handler` opened one `NamedTemporaryFile` per partition for the life of the run (5-year hourly = ~43k open fds). `__enter__` clobbered `_state` on re-entry. `_get_handler` had no `BaseException` guard. Replaced unbounded state with bounded `OrderedDict` LRU (default 256, configurable via `max_open_writers`); evicted writers reopen in `a+b` and append (fastavro detects the existing container, reuses the sync marker, no header duplication); `__enter__` raises `RuntimeError` on re-entry; tempfile creation now mirrors the `_serialize_asset_to_tempfile` `BaseException`/cleanup pattern.
- **#201** `perf(catalog): keep small avro payloads in memory` — `_serialize_asset_to_tempfile` wrote to a `NamedTemporaryFile`, closed it, then `store_asset_async` reopened it by path. New `spool_threshold_bytes` Catalog kwarg (default 8 MiB) — payloads ≤ threshold serialize to a `BytesIO` and upload from RAM; larger payloads keep the on-disk path. fastavro only needs seek/tell, which `BytesIO` provides.

Each issue was implemented in its own worktree on `v2.0-wave-1-iss-{201,202,203}` and merged into `v2.0-wave-1` here.

## Verification

- `poetry run pytest -q` → **641 passed, 0 failed** on the bundled branch (4 new `test_aiter_callable_*`, 4 new `test_serialize_spool_*`, 4 new `TestAssetRepartitionerHardening::test_repartitioner_*`).
- `poetry run pre-commit run --all-files` → ruff, mypy, detect-secrets, all hooks pass.
- `poetry run lint-imports` → **5/5 DDD contracts kept**.

## Test plan

- [x] Full pytest suite green on bundled branch
- [x] Pre-commit (ruff + mypy + detect-secrets) clean
- [x] Import-linter contracts kept (no new layer violations)
- [x] CHANGELOG entry added under `Unreleased — v2.0 (in progress)` / `Wave 1`
- [ ] Reviewer: confirm the streaming-reopen LRU strategy in #202 is acceptable vs the alternatives (concat-on-close, memory-buffer-then-flush) called out in the issue.
- [ ] Reviewer: confirm 8 MiB default for `spool_threshold_bytes` is reasonable; profile-tune later if needed (per the issue note).

Closes #201
Closes #202
Closes #203